### PR TITLE
Flesh out basic API for Gc<T>

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
 
 static BOEHM_REPO: &str = "https://github.com/ivmai/bdwgc.git";

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1,0 +1,47 @@
+use std::{
+    alloc::{AllocErr, AllocRef, GlobalAlloc, Layout},
+    ffi::c_void,
+    ptr::NonNull,
+};
+
+use crate::boehm;
+
+pub struct GlobalAllocator;
+pub struct GcAllocator;
+
+unsafe impl GlobalAlloc for GlobalAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        boehm::GC_malloc_uncollectable(layout.size()) as *mut u8
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, _: Layout) {
+        boehm::GC_free(ptr as *mut c_void);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, _: Layout, new_size: usize) -> *mut u8 {
+        boehm::GC_realloc(ptr as *mut c_void, new_size) as *mut u8
+    }
+}
+
+unsafe impl AllocRef for GcAllocator {
+    fn alloc(&mut self, layout: Layout) -> Result<(NonNull<u8>, usize), AllocErr> {
+        let ptr = unsafe { boehm::GC_malloc(layout.size()) } as *mut u8;
+        assert!(!ptr.is_null());
+        Ok((unsafe { NonNull::new_unchecked(ptr) }, layout.size()))
+    }
+
+    unsafe fn dealloc(&mut self, _: NonNull<u8>, _: Layout) {}
+
+    unsafe fn realloc(
+        &mut self,
+        ptr: NonNull<u8>,
+        _layout: Layout,
+        new_size: usize,
+    ) -> Result<(NonNull<u8>, usize), AllocErr> {
+        let cptr = ptr.as_ptr() as *mut c_void;
+        Ok((
+            NonNull::new_unchecked(boehm::GC_realloc(cptr, new_size) as *mut u8),
+            new_size,
+        ))
+    }
+}

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -1,0 +1,241 @@
+use std::{
+    alloc::{AllocRef, Layout},
+    any::Any,
+    ffi::c_void,
+    fmt,
+    marker::PhantomData,
+    mem::{forget, transmute, ManuallyDrop, MaybeUninit},
+    num::NonZeroUsize,
+    ops::{Deref, DerefMut},
+    ptr::NonNull,
+};
+
+use crate::boehm;
+use crate::GC_ALLOCATOR;
+
+/// A garbage collected pointer.
+///
+/// The type `Gc<T>` provides shared ownership of a value of type `T`,
+/// allocted in the heap. `Gc` pointers are `Copyable`, so new pointers to
+/// the same value in the heap can be produced trivially. The lifetime of
+/// `T` is tracked automatically: it is freed when the application
+/// determines that no references to `T` are in scope. This does not happen
+/// deterministically, and no guarantees are given about when a value
+/// managed by `Gc` is freed.
+///
+/// Shared references in Rust disallow mutation by default, and `Gc` is no
+/// exception: you cannot generally obtain a mutable reference to something
+/// inside an `Gc`. If you need mutability, put a `Cell` or `RefCell` inside
+/// the `Gc`.
+///
+/// Unlike `Rc<T>`, cycles between `Gc` pointers are allowed and can be
+/// deallocated without issue.
+///
+/// `Gc<T>` automatically dereferences to `T` (via the `Deref` trait), so
+/// you can call `T`'s methods on a value of type `Gc<T>`.
+#[derive(PartialEq, Eq, Debug)]
+pub struct Gc<T: ?Sized> {
+    ptr: NonNull<GcBox<T>>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> Gc<T> {
+    /// Constructs a new `Gc<T>`.
+    pub fn new(v: T) -> Self {
+        Gc {
+            ptr: unsafe { NonNull::new_unchecked(GcBox::new(v)) },
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Constructs a new `Gc<MaybeUninit<T>>` which is capable of storing data
+    /// up-to the size permissible by `layout`.
+    ///
+    /// This can be useful if you want to store a value with a custom layout,
+    /// but have the collector treat the value as if it were T.
+    ///
+    /// `layout` must be at least as large as `T`, and have an alignment which
+    /// is the same, or bigger than, `T`.
+    pub fn new_from_layout(layout: Layout) -> Option<Gc<MaybeUninit<T>>> {
+        let tl = Layout::new::<T>();
+        if layout.size() < tl.size() && layout.align() >= tl.align() {
+            return None;
+        }
+        Some(Gc::from_inner(GcBox::new_from_layout(layout)))
+    }
+}
+
+impl Gc<dyn Any> {
+    pub fn downcast<T: Any>(&self) -> Result<Gc<T>, Gc<dyn Any>> {
+        if (*self).is::<T>() {
+            let ptr = self.ptr.cast::<GcBox<T>>();
+            Ok(Gc::from_inner(ptr))
+        } else {
+            Err(Gc::from_inner(self.ptr))
+        }
+    }
+}
+
+impl<T: ?Sized> Gc<T> {
+    /// Get a raw pointer to the underlying value `T`.
+    pub fn into_raw(this: Self) -> *const T {
+        this.ptr.as_ptr() as *const T
+    }
+
+    pub fn ptr_eq(this: &Self, other: &Self) -> bool {
+        this.ptr.as_ptr() == other.ptr.as_ptr()
+    }
+
+    pub fn from_raw(raw: *const T) -> Gc<T> {
+        Gc {
+            ptr: unsafe { NonNull::new_unchecked(raw as *mut GcBox<T>) },
+            _phantom: PhantomData,
+        }
+    }
+
+    fn from_inner(ptr: NonNull<GcBox<T>>) -> Self {
+        Self {
+            ptr,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> Gc<MaybeUninit<T>> {
+    /// As with `MaybeUninit::assume_init`, it is up to the caller to guarantee
+    /// that the inner value really is in an initialized state. Calling this
+    /// when the content is not yet fully initialized causes immediate undefined
+    /// behaviour.
+    pub unsafe fn assume_init(self) -> Gc<T> {
+        let ptr = self.ptr.as_ptr() as *mut GcBox<MaybeUninit<T>>;
+        Gc::from_inner((&mut *ptr).assume_init())
+    }
+}
+
+impl<T: ?Sized + fmt::Display> fmt::Display for Gc<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+/// A `GcBox` is a 0-cost wrapper which allows a single `Drop` implementation
+/// while also permitting multiple, copyable `Gc` references. The `drop` method
+/// on `GcBox` acts as a guard, preventing the destructors on its contents from
+/// running unless the object is really dead.
+struct GcBox<T: ?Sized>(ManuallyDrop<T>);
+
+impl<T> GcBox<T> {
+    fn new(value: T) -> *mut GcBox<T> {
+        let (layout, _) = Layout::new::<usize>().extend(Layout::new::<T>()).unwrap();
+        let base_ptr = unsafe { GC_ALLOCATOR.alloc(layout).unwrap().0.as_ptr() };
+        let gcbox = GcBox(ManuallyDrop::new(value));
+        let obj_ptr = unsafe { (base_ptr as *mut usize).add(1) } as *mut GcBox<T>;
+
+        unsafe {
+            obj_ptr.copy_from_nonoverlapping(&gcbox, 1);
+        }
+
+        GcBox::register_finalizer(unsafe { &mut *obj_ptr });
+        forget(gcbox);
+        obj_ptr
+    }
+
+    fn register_finalizer(&mut self) {
+        unsafe extern "C" fn fshim(obj: *mut c_void, _meta: *mut c_void) {
+            let vptr = *(obj as *mut Option<NonZeroUsize>);
+            match vptr {
+                Some(nzptr) => {
+                    let objptr = (obj as *mut usize).add(1);
+                    let flzr = transmute::<(usize, usize), &mut dyn Finalize>((
+                        objptr as usize,
+                        nzptr.get(),
+                    ));
+                    flzr.finalize()
+                }
+                None => return,
+            }
+        }
+        unsafe {
+            let fatptr: &mut dyn Finalize = self;
+            let vptr = NonZeroUsize::new_unchecked(
+                transmute::<&mut dyn Finalize, (usize, usize)>(fatptr).1,
+            );
+
+            let base_ptr = (self as *mut _ as *mut usize).sub(1) as *mut Option<NonZeroUsize>;
+
+            ::std::ptr::write(base_ptr, Some(vptr));
+
+            boehm::GC_register_finalizer(
+                base_ptr as *mut _ as *mut ::std::ffi::c_void,
+                fshim,
+                ::std::ptr::null_mut(),
+                ::std::ptr::null_mut(),
+                ::std::ptr::null_mut(),
+            );
+        }
+    }
+
+    fn new_from_layout(layout: Layout) -> NonNull<GcBox<MaybeUninit<T>>> {
+        unsafe {
+            let (nl, _) = Layout::new::<usize>().extend(layout).unwrap();
+            let base_ptr = GC_ALLOCATOR.alloc(nl).unwrap().0.as_ptr() as *mut usize;
+
+            // Placeholder for vptr
+            ::std::ptr::write(base_ptr as *mut Option<NonZeroUsize>, None);
+
+            NonNull::new_unchecked((base_ptr.add(1)) as *mut GcBox<MaybeUninit<T>>)
+        }
+    }
+}
+
+impl<T> GcBox<MaybeUninit<T>> {
+    unsafe fn assume_init(&mut self) -> NonNull<GcBox<T>> {
+        // With T now considered initialized, we must make sure that if GcBox<T>
+        // is reclaimed, T will be dropped. We need to find its vptr and replace the
+        // GcDummyDrop vptr in the block header with it.
+        self.register_finalizer();
+        NonNull::new_unchecked(self as *mut _ as *mut GcBox<T>)
+    }
+}
+
+/// Used to clean up resources after a garbage collection.
+///
+/// A `Finalize` trait can be thought of as similar to `Drop`. Its `finalize`
+/// method is called by the GC when the object is considered garbage. We avoid
+/// `Drop` and use an explicit `Finalize` trait for this because `Drop` is
+/// special-cased in compiler and we want to avoid prematurely dropping fields
+/// pointing to other `GcBox`s.
+trait Finalize {
+    fn finalize(&mut self);
+}
+
+impl<T> Finalize for GcBox<T> {
+    fn finalize(&mut self) {
+        unsafe { ManuallyDrop::drop(&mut self.0) };
+    }
+}
+
+impl<T: ?Sized> Deref for Gc<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*(self.ptr.as_ptr() as *const T) }
+    }
+}
+
+impl<T: ?Sized> DerefMut for Gc<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *(self.ptr.as_ptr() as *mut T) }
+    }
+}
+
+/// `Copy` and `Clone` are implemented manually because a reference to `Gc<T>`
+/// should be copyable regardless of `T`. It differs subtly from `#[derive(Copy,
+/// Clone)]` in that the latter only makes `Gc<T>` copyable if `T` is.
+impl<T: ?Sized> Copy for Gc<T> {}
+
+impl<T: ?Sized> Clone for Gc<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,23 @@
+#![feature(core_intrinsics)]
+#![feature(allocator_api)]
+#![feature(alloc_layout_extra)]
+#![feature(raw_vec_internals)]
+#![feature(const_fn)]
+#![feature(coerce_unsized)]
+#![feature(unsize)]
+#![feature(maybe_uninit_ref)]
+#[cfg(not(all(target_pointer_width = "64", target_arch = "x86_64")))]
+compile_error!("Requires x86_64 with 64 bit pointer width.");
 
+pub mod gc;
+
+mod allocator;
+mod boehm;
+
+pub use gc::Gc;
+
+use crate::allocator::{GcAllocator, GlobalAllocator};
+
+#[global_allocator]
+static ALLOCATOR: GlobalAllocator = GlobalAllocator;
+static mut GC_ALLOCATOR: GcAllocator = GcAllocator;


### PR DESCRIPTION
This commit is fairly large unfortunately. However, much of it will be
familiar as it's been copied from gcmalloc. The key difference is how
we deal with finalization. Unlike gcmalloc, which used `Drop` for both
destruction and finalization, rboehm introduces a new `Finalizable`
trait

Gcmalloc was able to reuse `Drop` because the `drop` method for `GcBox`
would guard the actual `drop` routine based on the object's marking
state. In other words, we would make sure `drop` code wouldn't actually
be called if the object was still alive. This isn't possible with the
Boehm GC as the marking state of an individual object during
finalization is not available. The `Finalizabe` trait therefore prevents
rustc from recursively calling drop on potential `GcBox`s
indiscriminately. Removing the `Drop` trait from `GcBox` guarantees that
a `GcBox` can now only be finalized explicitly from the finalization
queue by calling `Finazable::finalize()`.

This doesn't affect flexibility from the users perspective. If a user
wants custom drop logic for a `Gc<T>` they would implement `Drop` on `T`
in the same way that they would in gcmalloc.