### PR TITLE
Link Boehm GC statically

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -10,8 +10,15 @@ sh rustup.sh --default-host x86_64-unknown-linux-gnu --default-toolchain nightly
 
 export PATH=`pwd`/.cargo/bin/:$PATH
 
-rustup component add --toolchain nightly rustfmt-preview || cargo +nightly install --force rustfmt-nightly
-
-cargo +nightly fmt --all
+# Sometimes rustfmt is so broken that there is no way to install it at all.
+# Rather than refusing to merge, we just can't rust rustfmt at such a point.
+rustup component add --toolchain nightly rustfmt-preview \
+    || cargo +nightly install --force rustfmt-nightly \
+    || true
+rustfmt=0
+cargo fmt 2>&1 | grep "not installed for the toolchain" > /dev/null || rustfmt=1
+if [ $rustfmt -eq 1 ]; then
+    cargo +nightly fmt --all -- --check
+fi
 
 cargo check


### PR DESCRIPTION
Cargo lacks the ability to specify arbitrary linker flags inside a build script. This means that we can't easily specify a custom `rpath` for our target. Dynamic linking is also not ideal because even if we could specify a custom `rpath`, it would need to be done by each consumer of rboehm. This isn't exactly user-friendly, and it's something that @vext01 is all too familiar with because of dynamic linking in the hwtracer.