### PR TITLE
Require consumer of library to specify the allocator

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -6,10 +6,10 @@ use std::{
 
 use crate::boehm;
 
-pub struct GlobalAllocator;
-pub struct GcAllocator;
+pub struct BoehmAllocator;
+pub(crate) struct BoehmGcAllocator;
 
-unsafe impl GlobalAlloc for GlobalAllocator {
+unsafe impl GlobalAlloc for BoehmAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         boehm::GC_malloc_uncollectable(layout.size()) as *mut u8
     }
@@ -23,7 +23,7 @@ unsafe impl GlobalAlloc for GlobalAllocator {
     }
 }
 
-unsafe impl AllocRef for GcAllocator {
+unsafe impl AllocRef for BoehmGcAllocator {
     fn alloc(&mut self, layout: Layout) -> Result<(NonNull<u8>, usize), AllocErr> {
         let ptr = unsafe { boehm::GC_malloc(layout.size()) } as *mut u8;
         assert!(!ptr.is_null());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,15 +9,15 @@
 #[cfg(not(all(target_pointer_width = "64", target_arch = "x86_64")))]
 compile_error!("Requires x86_64 with 64 bit pointer width.");
 
-pub mod gc;
-
-mod allocator;
 mod boehm;
 
+pub mod allocator;
+pub mod gc;
+
 pub use gc::Gc;
+pub use crate::allocator::BoehmAllocator;
 
-use crate::allocator::{GcAllocator, GlobalAllocator};
+use crate::allocator::BoehmGcAllocator;
 
-#[global_allocator]
-static ALLOCATOR: GlobalAllocator = GlobalAllocator;
-static mut GC_ALLOCATOR: GcAllocator = GcAllocator;
+static mut GC_ALLOCATOR: BoehmGcAllocator = BoehmGcAllocator;
+


### PR DESCRIPTION
It's a bit of a shame that this is necessary, since it requires all
consumers of the library to add the following boilerplate:

    #[global_allocator]
    static ALLOCATOR: BoehmAllocator = BoehmAllocator;

However, replacing the global allocator in the library leads to some
rather surprising consequences which are difficult to debug. This is
because the mere inclusion of `rboehm` in the `dependencies` section
of a project's `Cargo.toml` is enough to replace the allocator for any
Rust target which has access to it.

This caused a bug in lang_tester because rboehm's allocator was being
used as the global allocator for the harness. This is because testing
and benchmarking harnesses use all dependencies in cargo's
`dependencies` section (as well as `dev-dependencies`). rboehm is not
currently thread-safe, which caused UB when used with lang_tester as it
uses a threadpool to run tests by default.

This fix also triggered a secondary realisation, which is that all
consumers of this library must run unit tests serially until the GC is
made thread-safe.