### PR TITLE
Don't finalize primitives

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(coerce_unsized)]
 #![feature(unsize)]
 #![feature(maybe_uninit_ref)]
+#![feature(specialization)]
 #[cfg(not(all(target_pointer_width = "64", target_arch = "x86_64")))]
 compile_error!("Requires x86_64 with 64 bit pointer width.");
 


### PR DESCRIPTION
Primitives don't have drop implementations, nor do they have field
destructors which need calling, so it is wasteful to enqueue them for
finalization.

Here are the results on a simple countdown-from-n yksom benchmark:
```
===> multitime results
1: ./target/release/yksom --cp lib/SOM while_benchmark.som
            Mean        Std.Dev.    Min         Median      Max
real        5.466       0.000       5.466       5.466       5.466
user        8.618       0.000       8.618       8.618       8.618
sys         0.297       0.000       0.297       0.297       0.297
```
Compared with before, where every Gc value was added to a
finalization queue:
```
===> multitime results: with Finalizers
1: ./target/release/yksom --cp lib/SOM/ while_benchmark.som
            Mean        Std.Dev.    Min         Median      Max
real        5.845       0.343       5.605       5.723       6.849
user        9.244       0.799       8.726       9.009       11.599
sys         0.377       0.043       0.331       0.365       0.493
```
We get about a 7% speed up, which isn't as much as I was hoping for. The
reason for this is probably because this approach isn't covariant. In
other words, if a Gc value contains an `Option<T>`, `NewType(T)`,
`Enum::Variant(T)`, etc, [ where `T : NoFinalize` ] then this
optimisation will not apply. This rules out quite a few common patterns
in yksom.

Auto traits would give us this, but unfortunately they go too far the
other way: `Option<T>` would not be finalized as we hope, but neither
would `Vec<T>`, which will cause leaks. I can't see a way to do better
than this without compiler knowledge of which fields have destructors.