### PR TITLE
Use gmake in preference to make, if the former is available.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ libc = "*"
 [build-dependencies]
 rerun_except = "0.1"
 num_cpus = "1.12"
+which = "3.1"
 
 [dev-dependencies]
 lang_tester = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,8 @@ use std::env;
 use std::path::PathBuf;
 use std::process::Command;
 
+use which::which;
+
 const BOEHM_REPO: &str = "https://github.com/ivmai/bdwgc.git";
 const BOEHM_ATOMICS_REPO: &str = "https://github.com/ivmai/libatomic_ops.git";
 const BOEHM_DIR: &str = "bdwgc";
@@ -49,7 +51,11 @@ fn main() {
     });
 
     let cpus = num_cpus::get();
-    run("make", |cmd| cmd.arg("-j").arg(format!("{}", cpus)));
+    let make_bin = match which("gmake") {
+        Ok(_) => "gmake",
+        Err(_) => "make",
+    };
+    run(make_bin, |cmd| cmd.arg("-j").arg(format!("{}", cpus)));
 
     let mut libpath = PathBuf::from(&boehm_src);
     libpath.push(BUILD_DIR);


### PR DESCRIPTION
boehm requires GNU make to build, but OpenBSD's (and, probably, other non-Linux OS's) make isn't GNU make. If a "gmake" binary is available, use that in preference to make.

Tested on Debian and OpenBSD.