### PR TITLE
Allow Gc to be used as a receiver type.

### DIFF
--- a/src/gc.rs
+++ b/src/gc.rs
@@ -4,9 +4,9 @@ use std::{
     ffi::c_void,
     fmt,
     hash::{Hash, Hasher},
-    marker::PhantomData,
+    marker::{PhantomData, Unsize},
     mem::{forget, ManuallyDrop, MaybeUninit},
-    ops::{Deref, DerefMut},
+    ops::{CoerceUnsized, Deref, DerefMut, DispatchFromDyn},
     ptr::NonNull,
 };
 
@@ -38,6 +38,9 @@ pub struct Gc<T: ?Sized> {
     ptr: NonNull<GcBox<T>>,
     _phantom: PhantomData<T>,
 }
+
+impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Gc<U>> for Gc<T> {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Gc<U>> for Gc<T> {}
 
 impl<T> Gc<T> {
     /// Constructs a new `Gc<T>`.
@@ -283,5 +286,40 @@ mod test {
             _x: usize,
         }
         Gc::<S>::new_from_layout(Layout::from_size_align(size_of::<S>(), 1).unwrap());
+    }
+
+    #[test]
+    fn test_dispatchable() {
+        struct S1 {
+            x: u64,
+        }
+        struct S2 {
+            y: u64,
+        }
+        trait T {
+            fn f(self: Gc<Self>) -> u64;
+        }
+        impl T for S1 {
+            fn f(self: Gc<Self>) -> u64 {
+                self.x
+            }
+        }
+        impl T for S2 {
+            fn f(self: Gc<Self>) -> u64 {
+                self.y
+            }
+        }
+
+        let s1 = S1 { x: 1 };
+        let s2 = S2 { y: 2 };
+        let s1gc: Gc<S1> = Gc::new(s1);
+        let s2gc: Gc<S2> = Gc::new(s2);
+        assert_eq!(s1gc.f(), 1);
+        assert_eq!(s2gc.f(), 2);
+
+        let s1gcd: Gc<T> = s1gc;
+        let s2gcd: Gc<T> = s2gc;
+        assert_eq!(s1gcd.f(), 1);
+        assert_eq!(s2gcd.f(), 2);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![feature(core_intrinsics)]
 #![feature(allocator_api)]
 #![feature(alloc_layout_extra)]
+#![feature(arbitrary_self_types)]
+#![feature(dispatch_from_dyn)]
 #![feature(raw_vec_internals)]
 #![feature(const_fn)]
 #![feature(coerce_unsized)]


### PR DESCRIPTION
By enabling CoerceUnsized and DispatchFromDyn, we can use Gc as a receiver type,
even in traits:

```
  trait T {
    fn f(self: Gc<Self>);
  }
```

Annoyingly, we only need to enable the arbitrary_self_types feature for the test this commit adds. Oh well.