### PR TITLE
Remove machine word increment.

### DIFF
--- a/src/gc.rs
+++ b/src/gc.rs
@@ -171,7 +171,7 @@ impl<T> GcBox<T> {
                 .unwrap()
                 .ptr
                 .as_ptr() as *mut usize;
-            NonNull::new_unchecked((base_ptr.add(1)) as *mut GcBox<MaybeUninit<T>>)
+            NonNull::new_unchecked(base_ptr as *mut GcBox<MaybeUninit<T>>)
         }
     }
 }


### PR DESCRIPTION
As far as I can see, the addition of a machine word to the baseptr is a) not needed (I don't think that rboehm stores anything at the baseptr itself) b) causes a segfault because an extra machine word of memory is not requested in new_from_layout.