### PR TITLE
Bump |which| version to 4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ libc = "*"
 [build-dependencies]
 rerun_except = "0.1"
 num_cpus = "1.12"
-which = "3.1"
+which = "4.0"


### PR DESCRIPTION
Older versions use the deprecated |failure| library, which fails our
security audit (pun absolutely intended).