### PR TITLE
Fix Gc<T> to only finalize values when T needs drop

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 #![feature(coerce_unsized)]
 #![feature(unsize)]
 #![feature(maybe_uninit_ref)]
-#![feature(specialization)]
 #[cfg(not(all(target_pointer_width = "64", target_arch = "x86_64")))]
 compile_error!("Requires x86_64 with 64 bit pointer width.");
 


### PR DESCRIPTION
This PR fixes a couple of bugs in rboehm's current finalization approach.

Additionally, switching to the `needs_drop` intrinsic lets us be more aggressive
about what values don't need finalizing. this gets us a large chunk of the way
there in terms of winning back some performance we lose in GC. the table below
show the results of running the rebench suite on yksom with these changes
(labelled comparison) against rboehm tot as a baseline (7a647b).
```
-------------------------------------------------------------------------------
  benchmark     executor    suite   extra   core   #samples   mean (ms)
-------------------------------------------------------------------------------
  bounce        baseline     micro       2      1   10         237
  bounce        comparison   micro       2      1   10         117
  bubblesort    baseline     micro       3      1   10         186
  bubblesort    comparison   micro       3      1   10         97
  deltablue     baseline     macro      50      1   10         100
  deltablue     comparison   macro      50      1   10         82
  dispatch      baseline     micro       2      1   10         106
  dispatch      comparison   micro       2      1   10         71
  fannkuch      baseline     micro       6      1   10         93
  fannkuch      comparison   micro       6      1   10         54
  fibonacci     baseline     micro       3      1   10         520
  fibonacci     comparison   micro       3      1   10         265
  fieldloop     baseline     micro       1      1   10         57
  fieldloop     comparison   micro       1      1   10         64
  graphsearch   baseline     macro       4      1   10         52
  graphsearch   comparison   macro       4      1   10         34
  integerloop   baseline     micro       2      1   10         210
  integerloop   comparison   micro       2      1   10         142
  jsonsmall     baseline     macro       1      1   10         188
  jsonsmall     comparison   macro       1      1   10         126
  list          baseline     micro       2      1   10         226
  list          comparison   micro       2      1   10         115
  loop          baseline     micro       5      1   10         296
  loop          comparison   micro       5      1   10         202
  mandelbrot    baseline     micro      30      1   10         482
  mandelbrot    comparison   micro      30      1   10         284
  nbody         baseline     macro     500      1   10         182
  nbody         comparison   macro     500      1   10         131
  pagerank      baseline     macro      40      1   10         276
  pagerank      comparison   macro      40      1   10         168
  permute       baseline     micro       3      1   10         182
  permute       comparison   micro       3      1   10         104
  queens        baseline     micro       2      1   10         156
  queens        comparison   micro       2      1   10         89
  quicksort     baseline     micro       1      1   10         63
  quicksort     comparison   micro       1      1   10         39
  recurse       baseline     micro       3      1   10         211
  recurse       comparison   micro       3      1   10         80
  richards      baseline     macro       1      1   0          failed
  richards      comparison   macro       1      1   10         2359
  sieve         baseline     micro       4      1   10         303
  sieve         comparison   micro       4      1   10         176
  storage       baseline     micro       1      1   10         90
  storage       comparison   micro       1      1   10         41
  sum           baseline     micro       2      1   10         100
  sum           comparison   micro       2      1   10         81
  towers        baseline     micro       2      1   10         198
  towers        comparison   micro       2      1   10         121
  treesort      baseline     micro       1      1   10         162
  treesort      comparison   micro       1      1   10         128
  whileloop     baseline     micro      10      1   0          failed
  whileloop     comparison   micro      10      1   10         161
```