### PR TITLE
Add support for integration with rustc_boehm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 authors = ["Jacob Hughes <jh@jakehughes.uk>"]
 edition = "2018"
 
+[features]
+# Enable this feature to turn on additional GC optimizations that are only
+# possible with the rustc_boehm fork of the compiler.
+rustc_boehm = []
+
 [dependencies]
 libc = "*"
 

--- a/build.rs
+++ b/build.rs
@@ -25,6 +25,12 @@ where
 }
 
 fn main() {
+    if env::var_os("CARGO_FEATURE_RUSTC_BOEHM").is_some() {
+        // The Boehm GC is already linked statically through the rustc_boehm
+        // fork, so there's no need to build it again here.
+        return;
+    }
+
     let out_dir = env::var("OUT_DIR").unwrap();
     let mut boehm_src = PathBuf::from(out_dir);
     boehm_src.push(BOEHM_DIR);

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1,6 +1,5 @@
 use std::{
     alloc::{AllocErr, AllocRef, GlobalAlloc, Layout},
-    ffi::c_void,
     ptr::NonNull,
 };
 
@@ -11,21 +10,21 @@ pub(crate) struct BoehmGcAllocator;
 
 unsafe impl GlobalAlloc for BoehmAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        boehm::GC_malloc_uncollectable(layout.size()) as *mut u8
+        boehm::gc_malloc_uncollectable(layout.size()) as *mut u8
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _: Layout) {
-        boehm::GC_free(ptr as *mut c_void);
+        boehm::gc_free(ptr);
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, _: Layout, new_size: usize) -> *mut u8 {
-        boehm::GC_realloc(ptr as *mut c_void, new_size) as *mut u8
+        boehm::gc_realloc(ptr, new_size) as *mut u8
     }
 }
 
 unsafe impl AllocRef for BoehmGcAllocator {
     fn alloc(&mut self, layout: Layout) -> Result<NonNull<[u8]>, AllocErr> {
-        let ptr = unsafe { boehm::GC_malloc(layout.size()) } as *mut u8;
+        let ptr = unsafe { boehm::gc_malloc(layout.size()) } as *mut u8;
         assert!(!ptr.is_null());
         let ptr = unsafe { NonNull::new_unchecked(ptr) };
         Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))

--- a/src/boehm.rs
+++ b/src/boehm.rs
@@ -1,24 +1,63 @@
-use libc::size_t;
+#[cfg(not(feature = "rustc_boehm"))]
+pub unsafe fn gc_malloc(size: usize) -> *mut u8 {
+    GC_malloc(size) as *mut u8
+}
 
-use std::ffi::c_void;
+#[cfg(not(feature = "rustc_boehm"))]
+pub unsafe fn gc_realloc(old: *mut u8, new_size: usize) -> *mut u8 {
+    GC_realloc(old, new_size) as *mut u8
+}
+
+#[cfg(not(feature = "rustc_boehm"))]
+pub unsafe fn gc_malloc_uncollectable(size: usize) -> *mut u8 {
+    GC_malloc_uncollectable(size) as *mut u8
+}
+
+#[cfg(not(feature = "rustc_boehm"))]
+pub unsafe fn gc_free(dead: *mut u8) {
+    GC_free(dead)
+}
+
+#[cfg(feature = "rustc_boehm")]
+pub unsafe fn gc_register_finalizer(
+    obj: *mut u8,
+    finalizer: unsafe extern "C" fn(*mut u8, *mut u8),
+    client_data: *mut u8,
+    old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
+    old_client_data: *mut *mut u8,
+) {
+    std::boehm::gc_register_finalizer(obj, finalizer, client_data, old_finalizer, old_client_data)
+}
+
+#[cfg(not(feature = "rustc_boehm"))]
+pub unsafe fn gc_register_finalizer(
+    obj: *mut u8,
+    finalizer: unsafe extern "C" fn(*mut u8, *mut u8),
+    client_data: *mut u8,
+    old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
+    old_client_data: *mut *mut u8,
+) {
+    GC_register_finalizer(obj, finalizer, client_data, old_finalizer, old_client_data)
+}
 
 #[link(name = "gc")]
+#[cfg(not(feature = "rustc_boehm"))]
 extern "C" {
     pub fn GC_gcollect();
 
-    pub fn GC_malloc(nbytes: size_t) -> *mut c_void;
+    pub fn GC_malloc(nbytes: usize) -> *mut u8;
 
-    pub fn GC_malloc_uncollectable(nbytes: size_t) -> *mut c_void;
+    pub fn GC_malloc_uncollectable(nbytes: usize) -> *mut u8;
 
-    pub fn GC_realloc(old: *mut c_void, new_size: size_t) -> *mut c_void;
+    pub fn GC_realloc(old: *mut u8, new_size: usize) -> *mut u8;
 
-    pub fn GC_free(dead: *mut c_void);
+    pub fn GC_free(dead: *mut u8);
 
     pub fn GC_register_finalizer(
-        ptr: *mut c_void,
-        finalizer: unsafe extern "C" fn(*mut c_void, *mut c_void),
-        client_data: *mut c_void,
-        old_finalizer: *mut extern "C" fn(*mut c_void, *mut c_void),
-        old_client_data: *mut *mut c_void,
+        ptr: *mut u8,
+        finalizer: unsafe extern "C" fn(*mut u8, *mut u8),
+        client_data: *mut u8,
+        old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
+        old_client_data: *mut *mut u8,
     );
 }

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -1,7 +1,6 @@
 use std::{
     alloc::{AllocRef, Layout},
     any::Any,
-    ffi::c_void,
     fmt,
     hash::{Hash, Hasher},
     marker::{PhantomData, Unsize},
@@ -115,7 +114,7 @@ impl<T: ?Sized> Gc<T> {
     /// # Safety
     ///
     /// The caller must guarantee that `raw` was allocated with `Gc::new()` or
-    /// `Gc::new_from_layout()`.
+    /// u8 `Gc::new_from_layout()`.
     ///
     /// It is legal for `raw` to be an interior pointer if `T` is valid for the
     /// size and alignment of the originally allocated block.
@@ -184,13 +183,13 @@ impl<T> GcBox<T> {
             return;
         }
 
-        unsafe extern "C" fn fshim<T>(obj: *mut c_void, _meta: *mut c_void) {
+        unsafe extern "C" fn fshim<T>(obj: *mut u8, _meta: *mut u8) {
             ManuallyDrop::drop(&mut *(obj as *mut ManuallyDrop<T>));
         }
 
         unsafe {
-            boehm::GC_register_finalizer(
-                self as *mut _ as *mut ::std::ffi::c_void,
+            boehm::gc_register_finalizer(
+                self as *mut _ as *mut u8,
                 fshim::<T>,
                 ::std::ptr::null_mut(),
                 ::std::ptr::null_mut(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,21 @@ compile_error!("Requires x86_64 with 64 bit pointer width.");
 
 mod boehm;
 
+#[cfg(not(feature = "rustc_boehm"))]
 pub mod allocator;
+
 pub mod gc;
 
-pub use crate::allocator::BoehmAllocator;
 pub use gc::Gc;
 
+#[cfg(feature = "rustc_boehm")]
+pub use std::boehm::BoehmAllocator;
+#[cfg(feature = "rustc_boehm")]
+pub use std::boehm::BoehmGcAllocator;
+
+#[cfg(not(feature = "rustc_boehm"))]
+pub use crate::allocator::BoehmAllocator;
+#[cfg(not(feature = "rustc_boehm"))]
 use crate::allocator::BoehmGcAllocator;
 
 static mut GC_ALLOCATOR: BoehmGcAllocator = BoehmGcAllocator;


### PR DESCRIPTION
This commit introduces a `rustc_boehm` feature. When enabled, rboehm
assumes it is being built with the rustc_boehm fork of rustc and will do
two things: 1) link statically to the BDWGC built with rustc_boehm; and
2) enable optimizations which rely on compiler support. This means that
users who wish to use the rustc_boehm fork for GC will also need to use
the rboehm crate with their project.

Right now, rustc_boehm and rboehm are developed alongside eachother and
roughly 90% of both implementations overlap. This duplication is a pain
to maintain and slows down development.

At the moment, I can't think of a compelling reason to keep a duplicate
of `src/gc.rs` -- the bulk of the Gc API -- inside the standard library
of the forked compiler. There are several advantages to avoiding this:
*much* faster compile times; easier debuggability; easier comparisons;
less duplication, etc.