### PR TITLE
Allow null fn pointer in `register_finalizer` API

### DIFF
--- a/src/boehm.rs
+++ b/src/boehm.rs
@@ -21,7 +21,7 @@ pub unsafe fn gc_free(dead: *mut u8) {
 #[cfg(feature = "rustc_boehm")]
 pub unsafe fn gc_register_finalizer(
     obj: *mut u8,
-    finalizer: unsafe extern "C" fn(*mut u8, *mut u8),
+    finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
     client_data: *mut u8,
     old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
     old_client_data: *mut *mut u8,
@@ -32,7 +32,7 @@ pub unsafe fn gc_register_finalizer(
 #[cfg(not(feature = "rustc_boehm"))]
 pub unsafe fn gc_register_finalizer(
     obj: *mut u8,
-    finalizer: unsafe extern "C" fn(*mut u8, *mut u8),
+    finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
     client_data: *mut u8,
     old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
     old_client_data: *mut *mut u8,
@@ -55,7 +55,7 @@ extern "C" {
 
     pub fn GC_register_finalizer(
         ptr: *mut u8,
-        finalizer: unsafe extern "C" fn(*mut u8, *mut u8),
+        finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
         client_data: *mut u8,
         old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
         old_client_data: *mut *mut u8,

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -190,7 +190,7 @@ impl<T> GcBox<T> {
         unsafe {
             boehm::gc_register_finalizer(
                 self as *mut _ as *mut u8,
-                fshim::<T>,
+                Some(fshim::<T>),
                 ::std::ptr::null_mut(),
                 ::std::ptr::null_mut(),
                 ::std::ptr::null_mut(),


### PR DESCRIPTION
The Boehm GC API allows a null fn pointer to be passed to
`gc_register_finalizer` in order to un-register any existing finalizers.
However, in Rust, it's UB to create a null function pointer. The
solution to this is to wrap the fn pointer type in an `Option`, and pass
a `None` in the null ptr case. At the C ABI level, the `None` is passed
as a null pointer as expected.