### PR TITLE
Add an API to unregister an existing finalizer

### DIFF
--- a/src/gc.rs
+++ b/src/gc.rs
@@ -99,6 +99,16 @@ impl Gc<dyn Any> {
     }
 }
 
+#[cfg(not(feature = "rustc_boehm"))]
+pub fn needs_finalizer<T>() -> bool {
+    std::mem::needs_drop::<T>()
+}
+
+#[cfg(feature = "rustc_boehm")]
+pub fn needs_finalizer<T>() -> bool {
+    std::mem::needs_finalizer::<T>()
+}
+
 impl<T: ?Sized> Gc<T> {
     /// Get a raw pointer to the underlying value `T`.
     pub fn into_raw(this: Self) -> *const T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "rustc_boehm", feature(gc))]
 #![feature(core_intrinsics)]
 #![feature(allocator_api)]
 #![feature(alloc_layout_extra)]


### PR DESCRIPTION
This is needed to optimize away unnecessary finalization in the future.