### PR TITLE
Add basic GC stats collection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ edition = "2018"
 # possible with the rustc_boehm fork of the compiler.
 rustc_boehm = []
 
+# Enable various GC based statistics. Stats are disabled by default as they have
+# a run-time cost and are expected to only be used for profiling purposes.
+gc_stats = []
+
 [dependencies]
 libc = "*"
 

--- a/src/boehm.rs
+++ b/src/boehm.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "gc_stats")]
+use crate::stats::ProfileStats;
+
 #[cfg(not(feature = "rustc_boehm"))]
 pub unsafe fn gc_malloc(size: usize) -> *mut u8 {
     GC_malloc(size) as *mut u8
@@ -40,24 +43,49 @@ pub unsafe fn gc_register_finalizer(
     GC_register_finalizer(obj, finalizer, client_data, old_finalizer, old_client_data)
 }
 
+#[cfg(not(feature = "rustc_boehm"))]
+#[cfg(feature = "gc_stats")]
+pub unsafe fn gc_start_performance_measurement() {
+    GC_start_performance_measurement();
+}
+
+#[cfg(not(feature = "rustc_boehm"))]
+#[cfg(feature = "gc_stats")]
+pub unsafe fn gc_get_full_gc_total_time() -> usize {
+    GC_get_full_gc_total_time()
+}
+
+#[cfg(not(feature = "rustc_boehm"))]
+#[cfg(feature = "gc_stats")]
+pub unsafe fn gc_get_prof_stats(prof_stats: *mut ProfileStats, stats_size: usize) -> usize {
+    GC_get_prof_stats(prof_stats, stats_size)
+}
+
 #[link(name = "gc")]
 #[cfg(not(feature = "rustc_boehm"))]
 extern "C" {
-    pub fn GC_gcollect();
+    fn GC_malloc(nbytes: usize) -> *mut u8;
 
-    pub fn GC_malloc(nbytes: usize) -> *mut u8;
+    fn GC_malloc_uncollectable(nbytes: usize) -> *mut u8;
 
-    pub fn GC_malloc_uncollectable(nbytes: usize) -> *mut u8;
+    fn GC_realloc(old: *mut u8, new_size: usize) -> *mut u8;
 
-    pub fn GC_realloc(old: *mut u8, new_size: usize) -> *mut u8;
+    fn GC_free(dead: *mut u8);
 
-    pub fn GC_free(dead: *mut u8);
-
-    pub fn GC_register_finalizer(
+    fn GC_register_finalizer(
         ptr: *mut u8,
         finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
         client_data: *mut u8,
         old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
         old_client_data: *mut *mut u8,
     );
+
+    #[cfg(feature = "gc_stats")]
+    fn GC_start_performance_measurement();
+
+    #[cfg(feature = "gc_stats")]
+    fn GC_get_full_gc_total_time() -> usize;
+
+    #[cfg(feature = "gc_stats")]
+    fn GC_get_prof_stats(prof_stats: *mut ProfileStats, stats_size: usize) -> usize;
 }

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -12,6 +12,15 @@ use std::{
 use crate::boehm;
 use crate::GC_ALLOCATOR;
 
+/// This is usually a no-op, but if `gc_stats` is enabled it will setup the GC
+/// for profiliing.
+pub fn gc_init() {
+    #[cfg(feature = "gc_stats")]
+    unsafe {
+        boehm::gc_start_performance_measurement();
+    }
+}
+
 /// A garbage collected pointer.
 ///
 /// The type `Gc<T>` provides shared ownership of a value of type `T`,
@@ -213,6 +222,9 @@ impl<T> GcBox<T> {
                 ::std::ptr::null_mut(),
             );
         }
+
+        #[cfg(feature = "gc_stats")]
+        crate::stats::NUM_REGISTERED_FINALIZERS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
     fn unregister_finalizer(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,9 @@ mod boehm;
 
 #[cfg(not(feature = "rustc_boehm"))]
 pub mod allocator;
-
 pub mod gc;
+#[cfg(feature = "gc_stats")]
+pub mod stats;
 
 pub use gc::Gc;
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,70 @@
+use crate::boehm;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+pub static NUM_REGISTERED_FINALIZERS: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Debug)]
+pub struct GcStats {
+    total_gc_time: usize, // In milliseconds.
+    num_collections: usize,
+    finalizers_registered: usize,
+    total_freed: usize,   // In bytes
+    total_alloced: usize, // In bytes
+}
+
+impl GcStats {
+    fn gen() -> Self {
+        let mut ps = ProfileStats::default();
+        unsafe {
+            boehm::gc_get_prof_stats(
+                &mut ps as *mut ProfileStats,
+                std::mem::size_of::<ProfileStats>(),
+            );
+        }
+
+        let total_gc_time = unsafe { boehm::gc_get_full_gc_total_time() };
+
+        GcStats {
+            total_gc_time,
+            num_collections: ps.gc_no,
+            finalizers_registered: NUM_REGISTERED_FINALIZERS.load(Ordering::Relaxed),
+            total_freed: ps.bytes_reclaimed_since_gc,
+            total_alloced: ps.bytes_allocd_since_gc,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Default)]
+pub struct ProfileStats {
+    /// Heap size in bytes (including area unmapped to OS).
+    heapsize_full: usize,
+    /// Total bytes contained in free and unmapped blocks.
+    free_bytes_full: usize,
+    /// Amount of memory unmapped to OS.
+    unmapped_bytes: usize,
+    /// Number of bytes allocated since the recent collection.
+    bytes_allocd_since_gc: usize,
+    /// Number of bytes allocated before the recent collection.
+    /// The value may wrap.
+    allocd_bytes_before_gc: usize,
+    /// Number of bytes not considered candidates for garbage collection.
+    non_gc_bytes: usize,
+    /// Garbage collection cycle number.
+    /// The value may wrap.
+    gc_no: usize,
+    /// Number of marker threads (excluding the initiating one).
+    markers_m1: usize,
+    /// Approximate number of reclaimed bytes after recent collection.
+    bytes_reclaimed_since_gc: usize,
+    /// Approximate number of bytes reclaimed before the recent collection.
+    /// The value may wrap.
+    reclaimed_bytes_before_gc: usize,
+    /// Number of bytes freed explicitly since the recent GC.
+    expl_freed_bytes_since_gc: usize,
+}
+
+#[cfg(feature = "gc_stats")]
+pub fn get_stats() -> GcStats {
+    GcStats::gen()
+}


### PR DESCRIPTION
This provides a way of displaying some useful metrics which will help
debug and profile the GC. Right now, we do not record metrics after each
collection. This is because libgc stops the world uncooperatively. In
other words, there is no "collect" prologue or epilogue to hook into.
These metrics are gated behind the "gc_stats" feature. Performance is
unaffected unless this feature is enabled.