### PR TITLE
Move boehm-specific stuff into its own crate

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -12,7 +12,7 @@ sh rustup.sh --default-host x86_64-unknown-linux-gnu \
     --profile minimal \
     -y
 export PATH=`pwd`/.cargo/bin/:$PATH
-cargo check
+cargo check --features use_boehm
 
 rustup toolchain install nightly --allow-downgrade --component rustfmt
 cargo +nightly fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Jacob Hughes <jh@jakehughes.uk>"]
 edition = "2018"
 
+[workspace]
+members = ["boehm"]
+
 [features]
 # Enable this feature to turn on additional GC optimizations that are only
 # possible with the rustc_boehm fork of the compiler.
@@ -13,8 +16,12 @@ rustc_boehm = []
 # a run-time cost and are expected to only be used for profiling purposes.
 gc_stats = []
 
+# Use boehm as a backend
+use_boehm = ["boehm"]
+
 [dependencies]
 libc = "*"
+boehm = { path = "boehm", optional = true }
 
 [build-dependencies]
 rerun_except = "0.1"

--- a/boehm/Cargo.toml
+++ b/boehm/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "boehm"
+version = "0.1.0"
+authors = ["Jacob Hughes <jh@jakehughes.uk>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/boehm/src/allocator.rs
+++ b/boehm/src/allocator.rs
@@ -3,28 +3,28 @@ use std::{
     ptr::NonNull,
 };
 
-use crate::boehm;
+use crate::ffi;
 
 pub struct BoehmAllocator;
-pub(crate) struct BoehmGcAllocator;
+pub struct BoehmGcAllocator;
 
 unsafe impl GlobalAlloc for BoehmAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        boehm::gc_malloc_uncollectable(layout.size()) as *mut u8
+        ffi::gc_malloc_uncollectable(layout.size()) as *mut u8
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _: Layout) {
-        boehm::gc_free(ptr);
+        ffi::gc_free(ptr);
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, _: Layout, new_size: usize) -> *mut u8 {
-        boehm::gc_realloc(ptr, new_size) as *mut u8
+        ffi::gc_realloc(ptr, new_size) as *mut u8
     }
 }
 
 unsafe impl AllocRef for BoehmGcAllocator {
     fn alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        let ptr = unsafe { boehm::gc_malloc(layout.size()) } as *mut u8;
+        let ptr = unsafe { ffi::gc_malloc(layout.size()) } as *mut u8;
         assert!(!ptr.is_null());
         let ptr = unsafe { NonNull::new_unchecked(ptr) };
         Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))

--- a/boehm/src/ffi.rs
+++ b/boehm/src/ffi.rs
@@ -44,21 +44,48 @@ pub unsafe fn gc_register_finalizer(
 }
 
 #[cfg(not(feature = "rustc_boehm"))]
-#[cfg(feature = "gc_stats")]
 pub unsafe fn gc_start_performance_measurement() {
     GC_start_performance_measurement();
 }
 
 #[cfg(not(feature = "rustc_boehm"))]
-#[cfg(feature = "gc_stats")]
 pub unsafe fn gc_get_full_gc_total_time() -> usize {
     GC_get_full_gc_total_time()
 }
 
 #[cfg(not(feature = "rustc_boehm"))]
-#[cfg(feature = "gc_stats")]
 pub unsafe fn gc_get_prof_stats(prof_stats: *mut ProfileStats, stats_size: usize) -> usize {
     GC_get_prof_stats(prof_stats, stats_size)
+}
+
+#[repr(C)]
+#[derive(Default)]
+pub struct ProfileStats {
+    /// Heap size in bytes (including area unmapped to OS).
+    pub(crate) heapsize_full: usize,
+    /// Total bytes contained in free and unmapped blocks.
+    pub(crate) free_bytes_full: usize,
+    /// Amount of memory unmapped to OS.
+    pub(crate) unmapped_bytes: usize,
+    /// Number of bytes allocated since the recent collection.
+    pub(crate) bytes_allocd_since_gc: usize,
+    /// Number of bytes allocated before the recent collection.
+    /// The value may wrap.
+    pub(crate) allocd_bytes_before_gc: usize,
+    /// Number of bytes not considered candidates for garbage collection.
+    pub(crate) non_gc_bytes: usize,
+    /// Garbage collection cycle number.
+    /// The value may wrap.
+    pub(crate) gc_no: usize,
+    /// Number of marker threads (excluding the initiating one).
+    pub(crate) markers_m1: usize,
+    /// Approximate number of reclaimed bytes after recent collection.
+    pub(crate) bytes_reclaimed_since_gc: usize,
+    /// Approximate number of bytes reclaimed before the recent collection.
+    /// The value may wrap.
+    pub(crate) reclaimed_bytes_before_gc: usize,
+    /// Number of bytes freed explicitly since the recent GC.
+    pub(crate) expl_freed_bytes_since_gc: usize,
 }
 
 #[link(name = "gc")]
@@ -80,12 +107,9 @@ extern "C" {
         old_client_data: *mut *mut u8,
     );
 
-    #[cfg(feature = "gc_stats")]
     fn GC_start_performance_measurement();
 
-    #[cfg(feature = "gc_stats")]
     fn GC_get_full_gc_total_time() -> usize;
 
-    #[cfg(feature = "gc_stats")]
     fn GC_get_prof_stats(prof_stats: *mut ProfileStats, stats_size: usize) -> usize;
 }

--- a/boehm/src/lib.rs
+++ b/boehm/src/lib.rs
@@ -1,0 +1,72 @@
+#![feature(allocator_api)]
+#![feature(nonnull_slice_from_raw_parts)]
+
+pub mod allocator;
+mod ffi;
+
+use std::mem::{needs_drop, ManuallyDrop};
+
+use ffi::ProfileStats;
+
+pub fn register_finalizer<T>(gcbox: *mut T) {
+    if !needs_drop::<T>() {
+        return;
+    }
+
+    unsafe extern "C" fn fshim<T>(obj: *mut u8, _meta: *mut u8) {
+        ManuallyDrop::drop(&mut *(obj as *mut ManuallyDrop<T>));
+    }
+
+    unsafe {
+        ffi::gc_register_finalizer(
+            gcbox as *mut u8,
+            Some(fshim::<T>),
+            ::std::ptr::null_mut(),
+            ::std::ptr::null_mut(),
+            ::std::ptr::null_mut(),
+        );
+    }
+}
+
+pub fn unregister_finalizer(gcbox: *mut u8) {
+    unsafe {
+        ffi::gc_register_finalizer(
+            gcbox,
+            None,
+            ::std::ptr::null_mut(),
+            ::std::ptr::null_mut(),
+            ::std::ptr::null_mut(),
+        );
+    }
+}
+
+pub struct BoehmStats {
+    pub total_gc_time: usize, // In milliseconds.
+    pub num_collections: usize,
+    pub total_freed: usize,   // In bytes
+    pub total_alloced: usize, // In bytes
+}
+
+impl BoehmStats {
+    pub fn gen() -> Self {
+        let mut ps = ProfileStats::default();
+        unsafe {
+            ffi::gc_get_prof_stats(
+                &mut ps as *mut ProfileStats,
+                std::mem::size_of::<ProfileStats>(),
+            );
+        }
+        let total_gc_time = unsafe { ffi::gc_get_full_gc_total_time() };
+
+        BoehmStats {
+            total_gc_time,
+            num_collections: ps.gc_no,
+            total_freed: ps.bytes_reclaimed_since_gc,
+            total_alloced: ps.bytes_allocd_since_gc,
+        }
+    }
+}
+
+pub fn init() {
+    unsafe { ffi::gc_start_performance_measurement() };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,10 +13,6 @@
 #[cfg(not(all(target_pointer_width = "64", target_arch = "x86_64")))]
 compile_error!("Requires x86_64 with 64 bit pointer width.");
 
-mod boehm;
-
-#[cfg(not(feature = "rustc_boehm"))]
-pub mod allocator;
 pub mod gc;
 #[cfg(feature = "gc_stats")]
 pub mod stats;
@@ -29,8 +25,8 @@ pub use std::boehm::BoehmAllocator;
 pub use std::boehm::BoehmGcAllocator;
 
 #[cfg(not(feature = "rustc_boehm"))]
-pub use crate::allocator::BoehmAllocator;
+pub use boehm::allocator::BoehmAllocator;
 #[cfg(not(feature = "rustc_boehm"))]
-use crate::allocator::BoehmGcAllocator;
+use boehm::allocator::BoehmGcAllocator;
 
 static mut GC_ALLOCATOR: BoehmGcAllocator = BoehmGcAllocator;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,4 +1,3 @@
-use crate::boehm;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub static NUM_REGISTERED_FINALIZERS: AtomicUsize = AtomicUsize::new(0);
@@ -12,59 +11,20 @@ pub struct GcStats {
     total_alloced: usize, // In bytes
 }
 
-impl GcStats {
-    fn gen() -> Self {
-        let mut ps = ProfileStats::default();
-        unsafe {
-            boehm::gc_get_prof_stats(
-                &mut ps as *mut ProfileStats,
-                std::mem::size_of::<ProfileStats>(),
-            );
-        }
-
-        let total_gc_time = unsafe { boehm::gc_get_full_gc_total_time() };
-
+#[cfg(feature = "gc_stats")]
+impl From<boehm::BoehmStats> for GcStats {
+    fn from(item: boehm::BoehmStats) -> Self {
         GcStats {
-            total_gc_time,
-            num_collections: ps.gc_no,
+            total_gc_time: item.total_gc_time,
+            num_collections: item.num_collections,
             finalizers_registered: NUM_REGISTERED_FINALIZERS.load(Ordering::Relaxed),
-            total_freed: ps.bytes_reclaimed_since_gc,
-            total_alloced: ps.bytes_allocd_since_gc,
+            total_freed: item.total_freed,
+            total_alloced: item.total_alloced,
         }
     }
 }
 
-#[repr(C)]
-#[derive(Default)]
-pub struct ProfileStats {
-    /// Heap size in bytes (including area unmapped to OS).
-    heapsize_full: usize,
-    /// Total bytes contained in free and unmapped blocks.
-    free_bytes_full: usize,
-    /// Amount of memory unmapped to OS.
-    unmapped_bytes: usize,
-    /// Number of bytes allocated since the recent collection.
-    bytes_allocd_since_gc: usize,
-    /// Number of bytes allocated before the recent collection.
-    /// The value may wrap.
-    allocd_bytes_before_gc: usize,
-    /// Number of bytes not considered candidates for garbage collection.
-    non_gc_bytes: usize,
-    /// Garbage collection cycle number.
-    /// The value may wrap.
-    gc_no: usize,
-    /// Number of marker threads (excluding the initiating one).
-    markers_m1: usize,
-    /// Approximate number of reclaimed bytes after recent collection.
-    bytes_reclaimed_since_gc: usize,
-    /// Approximate number of bytes reclaimed before the recent collection.
-    /// The value may wrap.
-    reclaimed_bytes_before_gc: usize,
-    /// Number of bytes freed explicitly since the recent GC.
-    expl_freed_bytes_since_gc: usize,
-}
-
 #[cfg(feature = "gc_stats")]
 pub fn get_stats() -> GcStats {
-    GcStats::gen()
+    GcStats::from(boehm::BoehmStats::gen())
 }


### PR DESCRIPTION
To experiment with different collector backends we need to decouple the
Boehm GC code from the more general GC API. I think the most sensible
way to do this is to house the glue code for each backend in its own
nested crate. The GC can then be built with the desired backend by using
the appropriate feature flag. For example, to build with boehm
(currently the only supported option):

    cargo build --features use_boehm

Although this commit has a large diff, it mainly consists of moving
boehm specific code into the boehm/ crate, which is specified as a
dependency in the root Cargo.toml.