### PR TITLE
Simplify Boehm FFI

### DIFF
--- a/boehm/src/allocator.rs
+++ b/boehm/src/allocator.rs
@@ -10,21 +10,21 @@ pub struct BoehmGcAllocator;
 
 unsafe impl GlobalAlloc for BoehmAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        ffi::gc_malloc_uncollectable(layout.size()) as *mut u8
+        ffi::GC_malloc_uncollectable(layout.size()) as *mut u8
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _: Layout) {
-        ffi::gc_free(ptr);
+        ffi::GC_free(ptr);
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, _: Layout, new_size: usize) -> *mut u8 {
-        ffi::gc_realloc(ptr, new_size) as *mut u8
+        ffi::GC_realloc(ptr, new_size) as *mut u8
     }
 }
 
 unsafe impl AllocRef for BoehmGcAllocator {
     fn alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        let ptr = unsafe { ffi::gc_malloc(layout.size()) } as *mut u8;
+        let ptr = unsafe { ffi::GC_malloc(layout.size()) } as *mut u8;
         assert!(!ptr.is_null());
         let ptr = unsafe { NonNull::new_unchecked(ptr) };
         Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))

--- a/boehm/src/ffi.rs
+++ b/boehm/src/ffi.rs
@@ -1,63 +1,6 @@
 #[cfg(feature = "gc_stats")]
 use crate::stats::ProfileStats;
 
-#[cfg(not(feature = "rustc_boehm"))]
-pub unsafe fn gc_malloc(size: usize) -> *mut u8 {
-    GC_malloc(size) as *mut u8
-}
-
-#[cfg(not(feature = "rustc_boehm"))]
-pub unsafe fn gc_realloc(old: *mut u8, new_size: usize) -> *mut u8 {
-    GC_realloc(old, new_size) as *mut u8
-}
-
-#[cfg(not(feature = "rustc_boehm"))]
-pub unsafe fn gc_malloc_uncollectable(size: usize) -> *mut u8 {
-    GC_malloc_uncollectable(size) as *mut u8
-}
-
-#[cfg(not(feature = "rustc_boehm"))]
-pub unsafe fn gc_free(dead: *mut u8) {
-    GC_free(dead)
-}
-
-#[cfg(feature = "rustc_boehm")]
-pub unsafe fn gc_register_finalizer(
-    obj: *mut u8,
-    finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
-    client_data: *mut u8,
-    old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
-    old_client_data: *mut *mut u8,
-) {
-    std::boehm::gc_register_finalizer(obj, finalizer, client_data, old_finalizer, old_client_data)
-}
-
-#[cfg(not(feature = "rustc_boehm"))]
-pub unsafe fn gc_register_finalizer(
-    obj: *mut u8,
-    finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
-    client_data: *mut u8,
-    old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
-    old_client_data: *mut *mut u8,
-) {
-    GC_register_finalizer(obj, finalizer, client_data, old_finalizer, old_client_data)
-}
-
-#[cfg(not(feature = "rustc_boehm"))]
-pub unsafe fn gc_start_performance_measurement() {
-    GC_start_performance_measurement();
-}
-
-#[cfg(not(feature = "rustc_boehm"))]
-pub unsafe fn gc_get_full_gc_total_time() -> usize {
-    GC_get_full_gc_total_time()
-}
-
-#[cfg(not(feature = "rustc_boehm"))]
-pub unsafe fn gc_get_prof_stats(prof_stats: *mut ProfileStats, stats_size: usize) -> usize {
-    GC_get_prof_stats(prof_stats, stats_size)
-}
-
 #[repr(C)]
 #[derive(Default)]
 pub struct ProfileStats {
@@ -89,17 +32,16 @@ pub struct ProfileStats {
 }
 
 #[link(name = "gc")]
-#[cfg(not(feature = "rustc_boehm"))]
 extern "C" {
-    fn GC_malloc(nbytes: usize) -> *mut u8;
+    pub(crate) fn GC_malloc(nbytes: usize) -> *mut u8;
 
-    fn GC_malloc_uncollectable(nbytes: usize) -> *mut u8;
+    pub(crate) fn GC_malloc_uncollectable(nbytes: usize) -> *mut u8;
 
-    fn GC_realloc(old: *mut u8, new_size: usize) -> *mut u8;
+    pub(crate) fn GC_realloc(old: *mut u8, new_size: usize) -> *mut u8;
 
-    fn GC_free(dead: *mut u8);
+    pub(crate) fn GC_free(dead: *mut u8);
 
-    fn GC_register_finalizer(
+    pub(crate) fn GC_register_finalizer(
         ptr: *mut u8,
         finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
         client_data: *mut u8,
@@ -107,9 +49,9 @@ extern "C" {
         old_client_data: *mut *mut u8,
     );
 
-    fn GC_start_performance_measurement();
+    pub(crate) fn GC_start_performance_measurement();
 
-    fn GC_get_full_gc_total_time() -> usize;
+    pub(crate) fn GC_get_full_gc_total_time() -> usize;
 
-    fn GC_get_prof_stats(prof_stats: *mut ProfileStats, stats_size: usize) -> usize;
+    pub(crate) fn GC_get_prof_stats(prof_stats: *mut ProfileStats, stats_size: usize) -> usize;
 }

--- a/boehm/src/lib.rs
+++ b/boehm/src/lib.rs
@@ -18,7 +18,7 @@ pub fn register_finalizer<T>(gcbox: *mut T) {
     }
 
     unsafe {
-        ffi::gc_register_finalizer(
+        ffi::GC_register_finalizer(
             gcbox as *mut u8,
             Some(fshim::<T>),
             ::std::ptr::null_mut(),
@@ -30,7 +30,7 @@ pub fn register_finalizer<T>(gcbox: *mut T) {
 
 pub fn unregister_finalizer(gcbox: *mut u8) {
     unsafe {
-        ffi::gc_register_finalizer(
+        ffi::GC_register_finalizer(
             gcbox,
             None,
             ::std::ptr::null_mut(),
@@ -51,12 +51,12 @@ impl BoehmStats {
     pub fn gen() -> Self {
         let mut ps = ProfileStats::default();
         unsafe {
-            ffi::gc_get_prof_stats(
+            ffi::GC_get_prof_stats(
                 &mut ps as *mut ProfileStats,
                 std::mem::size_of::<ProfileStats>(),
             );
         }
-        let total_gc_time = unsafe { ffi::gc_get_full_gc_total_time() };
+        let total_gc_time = unsafe { ffi::GC_get_full_gc_total_time() };
 
         BoehmStats {
             total_gc_time,
@@ -68,5 +68,5 @@ impl BoehmStats {
 }
 
 pub fn init() {
-    unsafe { ffi::gc_start_performance_measurement() };
+    unsafe { ffi::GC_start_performance_measurement() };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,14 +19,7 @@ pub mod stats;
 
 pub use gc::Gc;
 
-#[cfg(feature = "rustc_boehm")]
-pub use std::boehm::BoehmAllocator;
-#[cfg(feature = "rustc_boehm")]
-pub use std::boehm::BoehmGcAllocator;
-
-#[cfg(not(feature = "rustc_boehm"))]
 pub use boehm::allocator::BoehmAllocator;
-#[cfg(not(feature = "rustc_boehm"))]
 use boehm::allocator::BoehmGcAllocator;
 
 static mut GC_ALLOCATOR: BoehmGcAllocator = BoehmGcAllocator;


### PR DESCRIPTION
We no longer conditionally link to libgc via rustc, so we can delete
lots of unnecessary indirection.