### PR TITLE
Fix build script to build boehm with `use_boehm` flag

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,9 +25,9 @@ where
 }
 
 fn main() {
-    if env::var_os("CARGO_FEATURE_RUSTC_BOEHM").is_some() {
-        // The Boehm GC is already linked statically through the rustc_boehm
-        // fork, so there's no need to build it again here.
+    if env::var_os("CARGO_FEATURE_USE_BOEHM").is_none() {
+        // The Boehm GC should only be built and linked if compiled with that
+        // feature flag.
         return;
     }
 


### PR DESCRIPTION
I had forgotten switch this over in 8e8501, and because my dependencies
were cached locally (and on the build server!), I didn't notice.