### PR TITLE
Switch to non-ordered finalization

### DIFF
--- a/boehm/src/ffi.rs
+++ b/boehm/src/ffi.rs
@@ -49,6 +49,14 @@ extern "C" {
         old_client_data: *mut *mut u8,
     );
 
+    pub(crate) fn GC_register_finalizer_no_order(
+        ptr: *mut u8,
+        finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
+        client_data: *mut u8,
+        old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
+        old_client_data: *mut *mut u8,
+    );
+
     pub(crate) fn GC_start_performance_measurement();
 
     pub(crate) fn GC_get_full_gc_total_time() -> usize;

--- a/boehm/src/lib.rs
+++ b/boehm/src/lib.rs
@@ -18,7 +18,7 @@ pub fn register_finalizer<T>(gcbox: *mut T) {
     }
 
     unsafe {
-        ffi::GC_register_finalizer(
+        ffi::GC_register_finalizer_no_order(
             gcbox as *mut u8,
             Some(fshim::<T>),
             ::std::ptr::null_mut(),
@@ -30,7 +30,7 @@ pub fn register_finalizer<T>(gcbox: *mut T) {
 
 pub fn unregister_finalizer(gcbox: *mut u8) {
     unsafe {
-        ffi::GC_register_finalizer(
+        ffi::GC_register_finalizer_no_order(
             gcbox,
             None,
             ::std::ptr::null_mut(),


### PR DESCRIPTION
Previously, finalization would happen in topological order.  In other
words, if A points to B, and both are finalizable, A is guaranteed to be
finalized first. This is problematic when cycles between finalizable
objects occur, since the collector can't know which to finalize first.
This means that until now, when cycles occur, finalizers would not be
run. In the context of a Rust GC, this has the potential for memory
leaks.

Switching to non-ordered finalization fixes this problem: there are no
longer any guarantees about which finalizer will run first, which means
cyclic objects can be finalized. However, the danger with non-ordered
finalization is that there must be no references to other GC'd objects
inside the finalizer. If such references exist, then the GC may crash
due to a dangling pointer. I don't believe this is a problem for us, as
we've been careful to avoid this pattern anyway.