### PR TITLE
Add support for passing object layout info to the GC

### DIFF
--- a/boehm/src/allocator.rs
+++ b/boehm/src/allocator.rs
@@ -7,6 +7,7 @@ use crate::ffi;
 
 pub struct BoehmAllocator;
 pub struct BoehmGcAllocator;
+pub struct PreciseAllocator;
 
 unsafe impl GlobalAlloc for BoehmAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
@@ -31,4 +32,36 @@ unsafe impl AllocRef for BoehmGcAllocator {
     }
 
     unsafe fn dealloc(&self, _: NonNull<u8>, _: Layout) {}
+}
+
+impl PreciseAllocator {
+    pub unsafe fn alloc_partially_traceable(
+        &self,
+        layout: Layout,
+        boundary: usize,
+    ) -> Result<NonNull<[u8]>, AllocError> {
+        // FIXME: Right now, this will only work for blocks smaller than 4KB.
+        assert!(layout.size() <= 4096);
+
+        // The idea here is simple. A bitmap is used to denote whether a
+        // particular word in an allocation block may hold a pointer. Each bit
+        // corresponds to a single word. A 1 indicates that a word *may* be a
+        // pointer, a 0 indicates that it definitely isn't.
+        //
+        // The boundary tells Boehm how far into the bitmap it should read. For
+        // example, a boundary of 4 means that only the first 4 bits in the
+        // bitmap are relevant, therefore only the first 4 words in the block
+        // are traced as candidate pointers.
+        //
+        // By setting all bits to 1, and specifying a boundary, we can take
+        // advantage of precise layout support to reduce the traceable region,
+        // without the complexity of having to provide accurate layouts for each
+        // type.
+        let bitmap: usize = 0xFFFFFFFF;
+        let gc_descr = ffi::GC_make_descriptor(&bitmap as *const usize, boundary);
+
+        let ptr = ffi::GC_malloc_explicitly_typed(layout.size(), gc_descr);
+        let ptr = NonNull::new_unchecked(ptr);
+        Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+    }
 }

--- a/boehm/src/ffi.rs
+++ b/boehm/src/ffi.rs
@@ -54,4 +54,8 @@ extern "C" {
     pub(crate) fn GC_get_full_gc_total_time() -> usize;
 
     pub(crate) fn GC_get_prof_stats(prof_stats: *mut ProfileStats, stats_size: usize) -> usize;
+
+    pub(crate) fn GC_malloc_explicitly_typed(size: usize, descriptor: usize) -> *mut u8;
+
+    pub(crate) fn GC_make_descriptor(bitmap: *const usize, len: usize) -> usize;
 }

--- a/boehm/src/ffi.rs
+++ b/boehm/src/ffi.rs
@@ -58,4 +58,6 @@ extern "C" {
     pub(crate) fn GC_malloc_explicitly_typed(size: usize, descriptor: usize) -> *mut u8;
 
     pub(crate) fn GC_make_descriptor(bitmap: *const usize, len: usize) -> usize;
+
+    pub(crate) fn GC_gcollect();
 }

--- a/boehm/src/lib.rs
+++ b/boehm/src/lib.rs
@@ -40,6 +40,10 @@ pub fn unregister_finalizer(gcbox: *mut u8) {
     }
 }
 
+pub fn force_gc() {
+    unsafe { ffi::GC_gcollect() }
+}
+
 pub struct BoehmStats {
     pub total_gc_time: usize, // In milliseconds.
     pub num_collections: usize,

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -1,5 +1,5 @@
 use std::{
-    alloc::{AllocRef, Layout},
+    alloc::{AllocError, AllocRef, Layout},
     any::Any,
     fmt,
     hash::{Hash, Hasher},
@@ -9,7 +9,7 @@ use std::{
     ptr::NonNull,
 };
 
-use crate::GC_ALLOCATOR;
+use crate::{GC_ALLOCATOR, PRECISE_ALLOCATOR};
 
 /// This is usually a no-op, but if `gc_stats` is enabled it will setup the GC
 /// for profiliing.
@@ -179,10 +179,31 @@ impl<T: ?Sized + fmt::Display> fmt::Display for Gc<T> {
 /// running unless the object is really dead.
 struct GcBox<T: ?Sized>(ManuallyDrop<T>);
 
+trait GcBoxAllocator {
+    fn alloc(layout: Layout) -> Result<NonNull<[u8]>, AllocError>;
+}
+
+impl<T> GcBoxAllocator for GcBox<T> {
+    default fn alloc(layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        GC_ALLOCATOR.alloc(layout)
+    }
+}
+
+impl<T: GcLayout> GcBoxAllocator for GcBox<T> {
+    fn alloc(layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        match T::layout_info() {
+            LayoutInfo::PartiallyTraceable(boundary) => unsafe {
+                PRECISE_ALLOCATOR.alloc_partially_traceable(layout, boundary)
+            },
+            LayoutInfo::Conservative => GC_ALLOCATOR.alloc(layout),
+        }
+    }
+}
+
 impl<T> GcBox<T> {
     fn new(value: T) -> *mut GcBox<T> {
         let layout = Layout::new::<T>();
-        let ptr = unsafe { GC_ALLOCATOR.alloc(layout).unwrap().as_ptr() } as *mut GcBox<T>;
+        let ptr = Self::alloc(layout).unwrap().as_ptr() as *mut GcBox<T>;
         let gcbox = GcBox(ManuallyDrop::new(value));
 
         unsafe {
@@ -213,6 +234,25 @@ impl<T> GcBox<T> {
         #[cfg(feature = "boehm")]
         boehm::unregister_finalizer(self as *mut _ as *mut u8);
     }
+}
+
+pub enum LayoutInfo {
+    /// A partially traceable type is conservatively traced up until a specified
+    /// word boundary.
+    PartiallyTraceable(usize),
+    /// The default tracing mechanism. This has the same effect as not
+    /// implementing `GcLayout`.
+    Conservative,
+}
+
+/// Used to pass more specific layout information about a type to the collector.
+///
+/// # Safety
+///
+/// This is very unsafe. Incorrect layout information can lead to the GC missing
+/// pointers, resulting in unsoundness.
+pub unsafe trait GcLayout {
+    fn layout_info() -> LayoutInfo;
 }
 
 impl<T> GcBox<MaybeUninit<T>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ pub use gc::Gc;
 pub use gc::GcLayout;
 pub use gc::LayoutInfo;
 
+#[cfg(feature = "use_boehm")]
+pub use boehm::force_gc;
+
 pub use boehm::allocator::BoehmAllocator;
 use boehm::allocator::BoehmGcAllocator;
 use boehm::allocator::PreciseAllocator;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,10 @@
 #![feature(coerce_unsized)]
 #![feature(unsize)]
 #![feature(maybe_uninit_ref)]
+#![feature(specialization)]
+// Suppress specialization warnings.
+#![allow(incomplete_features)]
+
 #[cfg(not(all(target_pointer_width = "64", target_arch = "x86_64")))]
 compile_error!("Requires x86_64 with 64 bit pointer width.");
 
@@ -18,8 +22,12 @@ pub mod gc;
 pub mod stats;
 
 pub use gc::Gc;
+pub use gc::GcLayout;
+pub use gc::LayoutInfo;
 
 pub use boehm::allocator::BoehmAllocator;
 use boehm::allocator::BoehmGcAllocator;
+use boehm::allocator::PreciseAllocator;
 
-static mut GC_ALLOCATOR: BoehmGcAllocator = BoehmGcAllocator;
+static GC_ALLOCATOR: BoehmGcAllocator = BoehmGcAllocator;
+static PRECISE_ALLOCATOR: PreciseAllocator = PreciseAllocator;


### PR DESCRIPTION
At the moment, our GC is fully conservative and scans all allocated
blocks. By providing layout hints, we can speed up marking by telling
the GC that it's safe to ignore certain locations in memory.

While the ultimate goal would be to provide precise layouts for each
allocated object, this is complex. So to start with, an easy win is to
tell the collector that certain objects have a cut-off boundary, after
which there are no more pointers to follow. We call these objects
partially traceable.

To tell the GC that a type `T` is partially traceable, the user must
implement the trait `GcLayout` for `T`. This trait has a method `layout_info`, 
where the user can choose one of two options:
    

- LayoutInfo::Conservative - The default, exact same result as not
specifying a layout hint at all.

-  LayoutInfo::PartiallyTraceable(usize) - Specifies that the collector
    will trace the object up until the provided word boundary. All


This is a rough first draft. Eventually I see this trait implementation
being sugared behind a procedural macro, but it seems to be a good first
approximation, and also feels naturally expandable to fit precise
layouts in the future too.

**Limitations:**

    

- Currently, the GC only looks at the GcLayout for types that are
    immediately inside a Gc. E.g. When T implements GcLayout, and is
    passed as a type constructor directly to Gc<T>, then the user
    provided layout information is used.

- PartiallyTraceable can only specify a lower boundary, not a
    "window" inside an object where the pointers may live.