### PR TITLE
Revert precise marking work in rboehm

### DIFF
--- a/boehm/src/allocator.rs
+++ b/boehm/src/allocator.rs
@@ -1,5 +1,5 @@
 use std::{
-    alloc::{AllocError, AllocRef, GlobalAlloc, Layout},
+    alloc::{AllocError, Allocator, GlobalAlloc, Layout},
     ptr::NonNull,
 };
 
@@ -22,13 +22,13 @@ unsafe impl GlobalAlloc for BoehmAllocator {
     }
 }
 
-unsafe impl AllocRef for BoehmGcAllocator {
-    fn alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+unsafe impl Allocator for BoehmGcAllocator {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         let ptr = unsafe { ffi::GC_malloc(layout.size()) } as *mut u8;
         assert!(!ptr.is_null());
         let ptr = unsafe { NonNull::new_unchecked(ptr) };
         Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
     }
 
-    unsafe fn dealloc(&self, _: NonNull<u8>, _: Layout) {}
+    unsafe fn deallocate(&self, _: NonNull<u8>, _: Layout) {}
 }

--- a/boehm/src/allocator.rs
+++ b/boehm/src/allocator.rs
@@ -7,7 +7,6 @@ use crate::ffi;
 
 pub struct BoehmAllocator;
 pub struct BoehmGcAllocator;
-pub struct PreciseAllocator;
 
 unsafe impl GlobalAlloc for BoehmAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
@@ -32,36 +31,4 @@ unsafe impl AllocRef for BoehmGcAllocator {
     }
 
     unsafe fn dealloc(&self, _: NonNull<u8>, _: Layout) {}
-}
-
-impl PreciseAllocator {
-    pub unsafe fn alloc_partially_traceable(
-        &self,
-        layout: Layout,
-        boundary: usize,
-    ) -> Result<NonNull<[u8]>, AllocError> {
-        // FIXME: Right now, this will only work for blocks smaller than 4KB.
-        assert!(layout.size() <= 4096);
-
-        // The idea here is simple. A bitmap is used to denote whether a
-        // particular word in an allocation block may hold a pointer. Each bit
-        // corresponds to a single word. A 1 indicates that a word *may* be a
-        // pointer, a 0 indicates that it definitely isn't.
-        //
-        // The boundary tells Boehm how far into the bitmap it should read. For
-        // example, a boundary of 4 means that only the first 4 bits in the
-        // bitmap are relevant, therefore only the first 4 words in the block
-        // are traced as candidate pointers.
-        //
-        // By setting all bits to 1, and specifying a boundary, we can take
-        // advantage of precise layout support to reduce the traceable region,
-        // without the complexity of having to provide accurate layouts for each
-        // type.
-        let bitmap: usize = 0xFFFFFFFF;
-        let gc_descr = ffi::GC_make_descriptor(&bitmap as *const usize, boundary);
-
-        let ptr = ffi::GC_malloc_explicitly_typed(layout.size(), gc_descr);
-        let ptr = NonNull::new_unchecked(ptr);
-        Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
-    }
 }

--- a/boehm/src/ffi.rs
+++ b/boehm/src/ffi.rs
@@ -63,9 +63,5 @@ extern "C" {
 
     pub(crate) fn GC_get_prof_stats(prof_stats: *mut ProfileStats, stats_size: usize) -> usize;
 
-    pub(crate) fn GC_malloc_explicitly_typed(size: usize, descriptor: usize) -> *mut u8;
-
-    pub(crate) fn GC_make_descriptor(bitmap: *const usize, len: usize) -> usize;
-
     pub(crate) fn GC_gcollect();
 }

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -1,5 +1,5 @@
 use std::{
-    alloc::{AllocRef, Layout},
+    alloc::{Allocator, Layout},
     any::Any,
     fmt,
     hash::{Hash, Hasher},
@@ -182,7 +182,7 @@ struct GcBox<T: ?Sized>(ManuallyDrop<T>);
 impl<T> GcBox<T> {
     fn new(value: T) -> *mut GcBox<T> {
         let layout = Layout::new::<T>();
-        let ptr = unsafe { GC_ALLOCATOR.alloc(layout).unwrap().as_ptr() } as *mut GcBox<T>;
+        let ptr = unsafe { GC_ALLOCATOR.allocate(layout).unwrap().as_ptr() } as *mut GcBox<T>;
         let gcbox = GcBox(ManuallyDrop::new(value));
 
         unsafe {
@@ -196,7 +196,7 @@ impl<T> GcBox<T> {
 
     fn new_from_layout(layout: Layout) -> NonNull<GcBox<MaybeUninit<T>>> {
         unsafe {
-            let base_ptr = GC_ALLOCATOR.alloc(layout).unwrap().as_ptr() as *mut usize;
+            let base_ptr = GC_ALLOCATOR.allocate(layout).unwrap().as_ptr() as *mut usize;
             NonNull::new_unchecked(base_ptr as *mut GcBox<MaybeUninit<T>>)
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,6 @@
 #![feature(coerce_unsized)]
 #![feature(unsize)]
 #![feature(maybe_uninit_ref)]
-#![feature(specialization)]
-// Suppress specialization warnings.
-#![allow(incomplete_features)]
-
 #[cfg(not(all(target_pointer_width = "64", target_arch = "x86_64")))]
 compile_error!("Requires x86_64 with 64 bit pointer width.");
 
@@ -22,15 +18,11 @@ pub mod gc;
 pub mod stats;
 
 pub use gc::Gc;
-pub use gc::GcLayout;
-pub use gc::LayoutInfo;
 
 #[cfg(feature = "use_boehm")]
 pub use boehm::force_gc;
 
 pub use boehm::allocator::BoehmAllocator;
 use boehm::allocator::BoehmGcAllocator;
-use boehm::allocator::PreciseAllocator;
 
-static GC_ALLOCATOR: BoehmGcAllocator = BoehmGcAllocator;
-static PRECISE_ALLOCATOR: PreciseAllocator = PreciseAllocator;
+static mut GC_ALLOCATOR: BoehmGcAllocator = BoehmGcAllocator;


### PR DESCRIPTION
After experimenting with various ways this sort of thing could work, I've converged on a more acceptable design which instead lives in rustc_boehm. The `GcLayout` trait, and its derivatives are no longer used in rboehm.   