### PR TITLE
Borsify rustgc

### DIFF
--- a/.buildbot.config.toml
+++ b/.buildbot.config.toml
@@ -1,0 +1,17 @@
+# Config file for continuous integration.
+
+[rust]
+codegen-units = 0           # Use many compilation units.
+debug-assertions = true     # Turn on assertions in rustc.
+
+[build]
+docs = false
+extended = false
+
+[llvm]
+assertions = true           # Turn on assertions in LLVM.
+use-linker = "gold"         # Uses less memory than ld.
+
+[install]
+prefix = "build/rustc_boehm"
+sysconfdir = "etc"

--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -16,3 +16,14 @@ cargo check
 
 rustup toolchain install nightly --allow-downgrade --component rustfmt
 cargo +nightly fmt --all -- --check
+
+# Build and test with rustgc
+git clone https://github.com/softdevteam/rustgc
+mkdir -p rustgc/build/rustgc
+(cd rustgc && ./x.py build --config ../.buildbot.config.toml)
+
+rustup toolchain link rustgc rustgc/build/x86_64-unknown-linux-gnu/stage1
+
+cargo clean
+
+cargo +rustgc test --features "rustgc"

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -112,12 +112,12 @@ impl Gc<dyn Any> {
     }
 }
 
-#[cfg(not(feature = "rustc_boehm"))]
+#[cfg(not(feature = "rustgc"))]
 pub fn needs_finalizer<T>() -> bool {
     std::mem::needs_drop::<T>()
 }
 
-#[cfg(feature = "rustc_boehm")]
+#[cfg(feature = "rustgc")]
 pub fn needs_finalizer<T>() -> bool {
     std::mem::needs_finalizer::<T>()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "rustc_boehm", feature(gc))]
+#![cfg_attr(feature = "rustgc", feature(gc))]
 #![feature(core_intrinsics)]
 #![feature(allocator_api)]
 #![feature(alloc_layout_extra)]


### PR DESCRIPTION
This adds test coverage for `--feature rustgc`. It can be merged once https://github.com/softdevteam/rustgc/pull/21 lands.