### PR TITLE
Update libgc to use single allocator

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -26,4 +26,4 @@ rustup toolchain link rustgc rustgc/build/x86_64-unknown-linux-gnu/stage1
 
 cargo clean
 
-cargo +rustgc test --features "rustgc"
+cargo +rustgc test --features "rustgc" -- --test-threads=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ gc_stats = []
 
 [dependencies]
 libc = "*"
-libgc_internal = { git = "https://github.com/softdevteam/libgc_internal" }
 
 [build-dependencies]
 rerun_except = "0.1"

--- a/README.md
+++ b/README.md
@@ -5,28 +5,14 @@ libgc is a garbage collector for Rust. It works by providing a garbage-collected
 
 # Structure
 
-There are three repositories which make up the gc infrastructure:
-    - **libgc** the main library which provides the `Gc<T>` smart pointer and its
+There are two repositories which make up the gc infrastructure:
+
+* **libgc** the main library which provides the `Gc<T>` smart pointer and its
       API.
-    - **libgc_internal** contains the gc allocation and collector logic. This is
-      collector specific, and can be conditionally compiled to support different
-      implementations. At the moment, it only supports a single collector
-      implementation: the Boehm-Demers-Weiser GC. Users should never interact
-      directly with this crate. Instead, any relevant APIs are re-exported
-      through libgc.
-    - **rustgc** a fork of rustc with GC-aware optimisations. This can be used to
+* **rustgc** a fork of rustc with GC-aware optimisations. This can be used to
       compile user programs which use `libgc`, giving them better GC
       performance. Use of rustgc is not mandated, but it enables further
       optimisations for programs which use `libgc`.
 
 This seperation between libgc and rustgc exists so that a stripped-down form of
-garbage collection can be used without compiler support. The further split
-between libgc and libgc_core exists to make linkage easier when the rustgc
-compiler is used.
-
-rustgc needs access to the GC's `Allocator` implementation. This exists in the
-libgc_internal crate so that it can be linked to the target binary either as
-part of libgc, or as part of the rust standard library (if compiled with
-rustgc). libgc contains code which would not compile if it was packaged as part
-of rustgc. To prevent duplication, the libgc_interal crate will link correctly
-as either a standard cargo crate, or as part of the rust core library.
+garbage collection can be used without compiler support. 

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1,0 +1,133 @@
+//! This library acts as a shim to prevent static linking the Boehm GC directly
+//! inside library/alloc which causes surprising and hard to debug errors.
+
+#![allow(dead_code)]
+
+use core::{
+    alloc::{AllocError, Allocator, GlobalAlloc, Layout},
+    ptr::NonNull,
+};
+
+pub struct GcAllocator;
+
+use crate::boehm;
+#[cfg(feature = "rustgc")]
+use crate::specializer;
+
+#[cfg(feature = "rustgc")]
+pub(crate) static ALLOCATOR: GcAllocator = GcAllocator;
+
+unsafe impl GlobalAlloc for GcAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        #[cfg(feature = "rustgc")]
+        return boehm::GC_malloc(layout.size()) as *mut u8;
+        #[cfg(not(feature = "rustgc"))]
+        return boehm::GC_malloc_uncollectable(layout.size()) as *mut u8;
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, _: Layout) {
+        boehm::GC_free(ptr);
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, _: Layout, new_size: usize) -> *mut u8 {
+        boehm::GC_realloc(ptr, new_size) as *mut u8
+    }
+
+    #[cfg(feature = "rustgc_internal")]
+    unsafe fn alloc_precise(&self, layout: Layout, bitmap: usize, bitmap_size: usize) -> *mut u8 {
+        let gc_descr = boehm::GC_make_descriptor(&bitmap, bitmap_size);
+        boehm::GC_malloc_explicitly_typed(layout.size(), gc_descr) as *mut u8
+    }
+
+    #[cfg(feature = "rustgc_internal")]
+    fn alloc_conservative(&self, layout: Layout) -> *mut u8 {
+        unsafe { boehm::GC_malloc(layout.size()) as *mut u8 }
+    }
+
+    #[cfg(feature = "rustgc_internal")]
+    unsafe fn alloc_atomic(&self, layout: Layout) -> *mut u8 {
+        boehm::GC_malloc_atomic(layout.size()) as *mut u8
+    }
+}
+
+unsafe impl Allocator for GcAllocator {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let ptr = unsafe { boehm::GC_malloc(layout.size()) } as *mut u8;
+        assert!(!ptr.is_null());
+        let ptr = unsafe { NonNull::new_unchecked(ptr) };
+        Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+    }
+
+    unsafe fn deallocate(&self, _: NonNull<u8>, _: Layout) {}
+}
+
+impl GcAllocator {
+    #[cfg(feature = "rustgc_internal")]
+    pub fn maybe_optimised_alloc<T>(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let sp = specializer::AllocationSpecializer::new();
+        sp.maybe_optimised_alloc::<T>(layout)
+    }
+
+    pub fn force_gc() {
+        unsafe { boehm::GC_gcollect() }
+    }
+
+    pub unsafe fn register_finalizer(
+        &self,
+        obj: *mut u8,
+        finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
+        client_data: *mut u8,
+        old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
+        old_client_data: *mut *mut u8,
+    ) {
+        boehm::GC_register_finalizer_no_order(
+            obj,
+            finalizer,
+            client_data,
+            old_finalizer,
+            old_client_data,
+        )
+    }
+
+    pub fn unregister_finalizer(&self, gcbox: *mut u8) {
+        unsafe {
+            boehm::GC_register_finalizer(
+                gcbox,
+                None,
+                ::core::ptr::null_mut(),
+                ::core::ptr::null_mut(),
+                ::core::ptr::null_mut(),
+            );
+        }
+    }
+
+    pub fn get_stats() -> GcStats {
+        let mut ps = boehm::ProfileStats::default();
+        unsafe {
+            boehm::GC_get_prof_stats(
+                &mut ps as *mut boehm::ProfileStats,
+                core::mem::size_of::<boehm::ProfileStats>(),
+            );
+        }
+        let total_gc_time = unsafe { boehm::GC_get_full_gc_total_time() };
+
+        GcStats {
+            total_gc_time,
+            num_collections: ps.gc_no,
+            total_freed: ps.bytes_reclaimed_since_gc,
+            total_alloced: ps.bytes_allocd_since_gc,
+        }
+    }
+
+    pub fn init() {
+        unsafe { boehm::GC_start_performance_measurement() };
+    }
+}
+
+#[derive(Debug)]
+pub struct GcStats {
+    total_gc_time: usize, // In milliseconds.
+    num_collections: usize,
+    total_freed: usize,   // In bytes
+    total_alloced: usize, // In bytes
+}

--- a/src/boehm.rs
+++ b/src/boehm.rs
@@ -1,0 +1,74 @@
+#[repr(C)]
+#[derive(Default)]
+pub struct ProfileStats {
+    /// Heap size in bytes (including area unmapped to OS).
+    pub(crate) heapsize_full: usize,
+    /// Total bytes contained in free and unmapped blocks.
+    pub(crate) free_bytes_full: usize,
+    /// Amount of memory unmapped to OS.
+    pub(crate) unmapped_bytes: usize,
+    /// Number of bytes allocated since the recent collection.
+    pub(crate) bytes_allocd_since_gc: usize,
+    /// Number of bytes allocated before the recent collection.
+    /// The value may wrap.
+    pub(crate) allocd_bytes_before_gc: usize,
+    /// Number of bytes not considered candidates for garbage collection.
+    pub(crate) non_gc_bytes: usize,
+    /// Garbage collection cycle number.
+    /// The value may wrap.
+    pub(crate) gc_no: usize,
+    /// Number of marker threads (excluding the initiating one).
+    pub(crate) markers_m1: usize,
+    /// Approximate number of reclaimed bytes after recent collection.
+    pub(crate) bytes_reclaimed_since_gc: usize,
+    /// Approximate number of bytes reclaimed before the recent collection.
+    /// The value may wrap.
+    pub(crate) reclaimed_bytes_before_gc: usize,
+    /// Number of bytes freed explicitly since the recent GC.
+    pub(crate) expl_freed_bytes_since_gc: usize,
+}
+
+#[link(name = "gc")]
+extern "C" {
+    pub(crate) fn GC_malloc(nbytes: usize) -> *mut u8;
+
+    #[cfg(not(feature = "rustgc"))]
+    pub(crate) fn GC_malloc_uncollectable(nbytes: usize) -> *mut u8;
+
+    pub(crate) fn GC_realloc(old: *mut u8, new_size: usize) -> *mut u8;
+
+    pub(crate) fn GC_free(dead: *mut u8);
+
+    pub(crate) fn GC_register_finalizer(
+        ptr: *mut u8,
+        finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
+        client_data: *mut u8,
+        old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
+        old_client_data: *mut *mut u8,
+    );
+
+    pub(crate) fn GC_register_finalizer_no_order(
+        ptr: *mut u8,
+        finalizer: Option<unsafe extern "C" fn(*mut u8, *mut u8)>,
+        client_data: *mut u8,
+        old_finalizer: *mut extern "C" fn(*mut u8, *mut u8),
+        old_client_data: *mut *mut u8,
+    );
+
+    pub(crate) fn GC_gcollect();
+
+    pub(crate) fn GC_start_performance_measurement();
+
+    pub(crate) fn GC_get_full_gc_total_time() -> usize;
+
+    pub(crate) fn GC_get_prof_stats(prof_stats: *mut ProfileStats, stats_size: usize) -> usize;
+
+    #[cfg(feature = "rustgc")]
+    pub(crate) fn GC_malloc_explicitly_typed(size: usize, descriptor: usize) -> *mut u8;
+
+    #[cfg(feature = "rustgc")]
+    pub(crate) fn GC_make_descriptor(bitmap: *const usize, len: usize) -> usize;
+
+    #[cfg(feature = "rustgc")]
+    pub(crate) fn GC_malloc_atomic(nbytes: usize) -> *mut u8;
+}

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -9,7 +9,7 @@ use std::{
     ptr::NonNull,
 };
 
-use crate::GC_ALLOCATOR;
+use crate::ALLOCATOR;
 
 /// This is usually a no-op, but if `gc_stats` is enabled it will setup the GC
 /// for profiliing.
@@ -182,7 +182,7 @@ struct GcBox<T: ?Sized>(ManuallyDrop<T>);
 impl<T> GcBox<T> {
     fn new(value: T) -> *mut GcBox<T> {
         let layout = Layout::new::<T>();
-        let ptr = unsafe { GC_ALLOCATOR.allocate(layout).unwrap().as_ptr() } as *mut GcBox<T>;
+        let ptr = ALLOCATOR.allocate(layout).unwrap().as_ptr() as *mut GcBox<T>;
         let gcbox = GcBox(ManuallyDrop::new(value));
 
         unsafe {
@@ -196,7 +196,7 @@ impl<T> GcBox<T> {
 
     fn new_from_layout(layout: Layout) -> NonNull<GcBox<MaybeUninit<T>>> {
         unsafe {
-            let base_ptr = GC_ALLOCATOR.allocate(layout).unwrap().as_ptr() as *mut usize;
+            let base_ptr = ALLOCATOR.allocate(layout).unwrap().as_ptr() as *mut usize;
             NonNull::new_unchecked(base_ptr as *mut GcBox<MaybeUninit<T>>)
         }
     }
@@ -214,7 +214,7 @@ impl<T> GcBox<T> {
         }
 
         unsafe {
-            GC_ALLOCATOR.register_finalizer(
+            ALLOCATOR.register_finalizer(
                 self as *mut _ as *mut u8,
                 Some(fshim::<T>),
                 ::std::ptr::null_mut(),
@@ -225,7 +225,7 @@ impl<T> GcBox<T> {
     }
 
     fn unregister_finalizer(&mut self) {
-        unsafe { GC_ALLOCATOR.unregister_finalizer(self as *mut _ as *mut u8) };
+        ALLOCATOR.unregister_finalizer(self as *mut _ as *mut u8);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,15 @@
 #![feature(alloc_layout_extra)]
 #![feature(arbitrary_self_types)]
 #![feature(dispatch_from_dyn)]
+#![feature(specialization)]
 #![feature(nonnull_slice_from_raw_parts)]
 #![feature(raw_vec_internals)]
 #![feature(const_fn)]
 #![feature(coerce_unsized)]
 #![feature(unsize)]
 #![feature(maybe_uninit_ref)]
+#![feature(negative_impls)]
+#![allow(incomplete_features)]
 #[cfg(not(all(target_pointer_width = "64", target_arch = "x86_64")))]
 compile_error!("Requires x86_64 with 64 bit pointer width.");
 
@@ -17,10 +20,12 @@ pub mod gc;
 #[cfg(feature = "gc_stats")]
 pub mod stats;
 
+mod allocator;
+mod boehm;
+#[cfg(feature = "rustgc")]
+mod specializer;
+
+pub use allocator::GcAllocator;
 pub use gc::Gc;
 
-use libgc_internal::GcAllocator;
-pub use libgc_internal::GlobalAllocator;
-
-static GC_ALLOCATOR: GcAllocator = GcAllocator;
-pub static GLOBAL_ALLOCATOR: GlobalAllocator = GlobalAllocator;
+pub static ALLOCATOR: GcAllocator = GcAllocator;

--- a/src/specializer.rs
+++ b/src/specializer.rs
@@ -1,0 +1,245 @@
+//! The contents of this module require the rustgc feature. To avoid polluting
+//! lib.rs with conditional compilation attributes, it is only exported if the
+//! rustgc feature is enabled.
+use core::{
+    alloc::{AllocError, Layout},
+    gc::{Conservative, NoTrace},
+    marker::PhantomData,
+    ptr::NonNull,
+};
+
+#[cfg(test)]
+use core::cell::Cell;
+
+use crate::boehm;
+use crate::ALLOCATOR;
+
+/// An allocation helper to potentially optimise the marking of allocated
+/// blocks.
+///
+/// Allocation which is done through this bottleneck will try to use type
+/// information to allocate blocks in pools which are better optimised for
+/// marking. Allocation is a hot path, so to reduce branching at runtime, it
+/// makes heavy use of specialization, hence the name. Specialized allocation
+/// can be thought of as "compile-time cascading if-else".
+///
+/// There are three ways a block can be allocated:
+///
+///    Atomically - this means that a block contains no pointers which need
+///    tracing during marking. An atomically allocated block is a leaf node in
+///    the object graph.
+///
+///    Precisely - blocks are allocated along with a bitmap which describes
+///    where the pointers are on a per-word basis. The parts of a block which
+///    are not described in the bitmap are ignored by the collector during
+///    marking.
+///
+///    Conservatively - the whereabouts of pointers inside the block are
+///    unknown, and each word in the block must be considered for potential
+///    pointers.
+///
+/// There is a direct trade-off between the safety and performance of these
+/// three allocation types: atomic allocation will have the fastest marking
+/// times, but is the most dangerous; whereas conservative allocation is safe to
+/// use anywhere, but will have the slowest marking times.
+///
+/// This approach, however, only works when an allocation block corresponds to
+/// the layout of a single type. This isn't always the case (hence, the
+/// allocator_api operates on a Layout, which deliberately carries less
+/// information than a type parameter). For example, it's perfectly legal in
+/// Rust to allocate a chunk of memory, and use it to store values of type X, Y,
+/// and Z contiguously (provided size and alignment constraints are met).
+/// Conservative allocation is currently the only safe way to allocate such
+/// blocks.
+#[cfg(test)]
+pub(crate) struct AllocationSpecializer {
+    num_atomic: Cell<usize>,
+    num_precise: Cell<usize>,
+    num_conservative: Cell<usize>,
+}
+
+#[cfg(not(test))]
+pub(crate) struct AllocationSpecializer;
+
+impl AllocationSpecializer {
+    #[cfg(test)]
+    pub(crate) fn new() -> Self {
+        Self {
+            num_atomic: Cell::new(0),
+            num_precise: Cell::new(0),
+            num_conservative: Cell::new(0),
+        }
+    }
+
+    #[cfg(not(test))]
+    pub(crate) fn new() -> Self {
+        Self
+    }
+
+    #[inline]
+    pub(crate) fn maybe_optimised_alloc<T>(
+        &self,
+        layout: Layout,
+    ) -> Result<NonNull<[u8]>, AllocError> {
+        ConservativeSpecializer::<T>::maybe_optimised_alloc(self, layout)
+    }
+
+    /// Allocates a block of memory for `layout` which is guaranteed to contains
+    /// no GC pointers.
+    ///
+    /// An atomic allocation has the same semantics as regular `alloc` except
+    /// for one key difference which is that it tells the collector not to trace
+    /// this block during marking.
+    ///
+    /// # Safety
+    ///
+    /// The block must not contain any pointers which, either directly or
+    /// transitively, point to a GC'd value.
+    unsafe fn atomic_alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let ptr = boehm::GC_malloc_atomic(layout.size()) as *mut u8;
+        let ptr = NonNull::new_unchecked(ptr);
+        #[cfg(test)]
+        {
+            self.num_atomic.set(self.num_atomic.get() + 1);
+        }
+        Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+    }
+
+    /// Allocates a block of memory for `layout` where word-aligned fields are
+    /// described to the collector by `bitmap`.
+    ///
+    /// An atomic allocation has the same semantics as regular `alloc` except
+    /// for one key difference which is that it tells the collector not to trace
+    /// this block during marking.
+    ///
+    /// # Safety
+    ///
+    /// The size described by `layout` must be no larger than 4092 bytes.
+    ///
+    /// An incorrect `bitmap` will lead to undefined behaviour.
+    ///
+    /// The size described by `layout` must be at least as big as
+    /// `size_of::<usize> * bitmap_size`.
+    ///
+    /// The returned pointer must not be passed to `realloc` under any
+    /// circumstances.
+    unsafe fn precise_alloc(
+        &self,
+        layout: Layout,
+        bitmap: u64,
+        bitmap_size: u64,
+    ) -> Result<NonNull<[u8]>, AllocError> {
+        let gc_descr =
+            boehm::GC_make_descriptor(&bitmap as *const u64 as *const usize, bitmap_size as usize);
+        let ptr = boehm::GC_malloc_explicitly_typed(layout.size(), gc_descr);
+        let ptr = NonNull::new_unchecked(ptr);
+        #[cfg(test)]
+        {
+            self.num_precise.set(self.num_precise.get() + 1);
+        }
+        Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+    }
+
+    /// Allocates a block of memory for `layout` which is traced conservatively
+    /// by the collector during marking.
+    fn conservative_alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let ptr = unsafe { boehm::GC_malloc(layout.size()) } as *mut u8;
+        let ptr = unsafe { NonNull::new_unchecked(ptr) };
+        #[cfg(test)]
+        {
+            self.num_conservative.set(self.num_conservative.get() + 1);
+        }
+        Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+    }
+}
+
+/// Specializes allocation for `T` based on its impl of the `Conservative` trait.
+///
+/// The implementation of `T: Conservative` will bypass all other allocation
+/// strategies and guarantee that the block required by `layout` is allocated
+/// conservatively.
+trait ConservativeSpecializer<T> {
+    fn maybe_optimised_alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError>;
+}
+
+impl<T> ConservativeSpecializer<T> for AllocationSpecializer {
+    default fn maybe_optimised_alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        AtomicSpecializer::<T>::maybe_optimised_alloc(self, layout)
+    }
+}
+
+impl<T: Conservative> ConservativeSpecializer<T> for AllocationSpecializer {
+    fn maybe_optimised_alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        self.conservative_alloc(layout)
+    }
+}
+
+/// Specializes allocation for `T` based on its impl of the `NoTrace` trait.
+///
+/// The implementation of `T: NoTrace` guarantees (provided that `T:
+/// !Conservative`) that the block required by `layout` is allocated atomically.
+trait AtomicSpecializer<T> {
+    fn maybe_optimised_alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError>;
+}
+
+impl<T> AtomicSpecializer<T> for AllocationSpecializer {
+    default fn maybe_optimised_alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        let trace = unsafe { ::core::gc::gc_layout::<T>() };
+        if trace.must_use_conservative() {
+            return self.conservative_alloc(layout);
+        }
+        unsafe { self.precise_alloc(layout, trace.bitmap, trace.size) }
+    }
+}
+
+impl<T: NoTrace> AtomicSpecializer<T> for AllocationSpecializer {
+    fn maybe_optimised_alloc(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        unsafe { self.atomic_alloc(layout) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atomic_alloc() {
+        struct T(usize);
+        impl NoTrace for T {}
+
+        struct U(usize);
+        impl !NoTrace for U {}
+
+        let sp = AllocationSpecializer::new();
+
+        sp.maybe_optimised_alloc::<T>(Layout::new::<T>());
+        assert_eq!(sp.num_atomic.get(), 1);
+
+        sp.maybe_optimised_alloc::<U>(Layout::new::<U>());
+        assert_eq!(sp.num_atomic.get(), 1);
+    }
+
+    #[test]
+    fn conservative_alloc() {
+        struct T(usize);
+
+        impl NoTrace for T {}
+        impl Conservative for T {}
+
+        let sp = AllocationSpecializer::new();
+
+        sp.maybe_optimised_alloc::<T>(Layout::new::<T>());
+        assert_eq!(sp.num_conservative.get(), 1);
+    }
+
+    #[test]
+    fn precise_alloc() {
+        struct T(usize);
+
+        impl !NoTrace for T {}
+
+        let sp = AllocationSpecializer::new();
+        sp.maybe_optimised_alloc::<T>(Layout::new::<T>());
+        assert_eq!(sp.num_precise.get(), 1);
+    }
+}


### PR DESCRIPTION
`libgc_internal` now uses a single allocator for both the `Allocator` and `GlobalAlloc` trait. This PR updates `libgc` to use that.