### PR TITLE
Make `Gc<T>` require bounds `T: Send + Sync`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 #![feature(maybe_uninit_ref)]
 #![feature(negative_impls)]
 #![allow(incomplete_features)]
+#![allow(where_clauses_object_safety)]
 #[cfg(not(all(target_pointer_width = "64", target_arch = "x86_64")))]
 compile_error!("Requires x86_64 with 64 bit pointer width.");
 


### PR DESCRIPTION
The collector finalizes objects off the main thread. This means that if
any fields are accessed via T's drop method, it must be done in a
thread-safe way.

A common pattern is to allow the `Gc<T>` to hold trait objects. For this
change to work, TO methods need a `where Self: Send + Sync` clause for
the compiler to guarantee object safety. Such clauses are deprecated in
rustc because they can be used to create UB when binding to user traits
with methods. However, at the time of this commit it's the only known
way to add additional bounds for auto traits. From my understanding this
usage is considered safe until a better situation arises [1].

[1]: https://github.com/rust-lang/rust/issues/50781#issuecomment-393615608