### PR TITLE
Fix bug where bool in `thread_registered` was inverted

### DIFF
--- a/allocator/src/lib.rs
+++ b/allocator/src/lib.rs
@@ -162,7 +162,7 @@ impl GcAllocator {
     }
 
     pub fn thread_registered() -> bool {
-        unsafe { boehm::GC_thread_is_registered() == 0 }
+        unsafe { boehm::GC_thread_is_registered() != 0 }
     }
 
     pub fn allow_register_threads() {


### PR DESCRIPTION
This unblocks https://github.com/softdevteam/rustgc/pull/31. 